### PR TITLE
[Feat] #17 - 피드, 홈, 보관함 탭바 구현

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -11,13 +11,13 @@
 		EBA77239278A2E14002958A5 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EBA77238278A2E14002958A5 /* Colors.xcassets */; };
 		F8096F042784107D00B71D38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F032784107D00B71D38 /* AppDelegate.swift */; };
 		F8096F062784107D00B71D38 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F052784107D00B71D38 /* SceneDelegate.swift */; };
-		F8096F0B2784107D00B71D38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8096F092784107D00B71D38 /* Main.storyboard */; };
+		F8096F0B2784107D00B71D38 /* Home.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8096F092784107D00B71D38 /* Home.storyboard */; };
 		F8096F0D2784107E00B71D38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8096F0C2784107E00B71D38 /* Assets.xcassets */; };
 		F8096F102784107E00B71D38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8096F0E2784107E00B71D38 /* LaunchScreen.storyboard */; };
 		F8096F2627841F0900B71D38 /* TempFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F2527841F0900B71D38 /* TempFont.swift */; };
 		F8096F2927841F1E00B71D38 /* Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F2827841F1E00B71D38 /* Const.swift */; };
 		F8096F2B27841F4100B71D38 /* Storyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F2A27841F4100B71D38 /* Storyboard.swift */; };
-		F8096F3027841F9200B71D38 /* MainVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F2F27841F9200B71D38 /* MainVC.swift */; };
+		F8096F3027841F9200B71D38 /* HomeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F2F27841F9200B71D38 /* HomeVC.swift */; };
 		F8096F3227841FE100B71D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F3127841FE100B71D38 /* ViewController.swift */; };
 		F8096F34278420F100B71D38 /* TempView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F33278420F100B71D38 /* TempView.swift */; };
 		F8096F36278420FA00B71D38 /* TempProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F35278420FA00B71D38 /* TempProtocol.swift */; };
@@ -29,6 +29,12 @@
 		F8096F422784214900B71D38 /* TempAppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F412784214900B71D38 /* TempAppModel.swift */; };
 		F8096F442784221900B71D38 /* Xib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F432784221900B71D38 /* Xib.swift */; };
 		F8096F462784247100B71D38 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F452784247100B71D38 /* Notification.swift */; };
+		F80A3E4D278C182100728E07 /* MainTabBar.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F80A3E4C278C182100728E07 /* MainTabBar.storyboard */; };
+		F80A3E4F278C18BA00728E07 /* MainTBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80A3E4E278C18BA00728E07 /* MainTBC.swift */; };
+		F80A3E51278C1BCE00728E07 /* Feed.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F80A3E50278C1BCE00728E07 /* Feed.storyboard */; };
+		F80A3E53278C1C0C00728E07 /* Storage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F80A3E52278C1C0C00728E07 /* Storage.storyboard */; };
+		F80A3E55278C1C1F00728E07 /* StorageVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80A3E54278C1C1F00728E07 /* StorageVC.swift */; };
+		F80A3E57278C1C2700728E07 /* FeedVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80A3E56278C1C2700728E07 /* FeedVC.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -39,14 +45,14 @@
 		F8096F002784107D00B71D38 /* Spark-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Spark-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8096F032784107D00B71D38 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F8096F052784107D00B71D38 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		F8096F0A2784107D00B71D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		F8096F0A2784107D00B71D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Home.storyboard; sourceTree = "<group>"; };
 		F8096F0C2784107E00B71D38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F8096F0F2784107E00B71D38 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F8096F112784107E00B71D38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8096F2527841F0900B71D38 /* TempFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempFont.swift; sourceTree = "<group>"; };
 		F8096F2827841F1E00B71D38 /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
 		F8096F2A27841F4100B71D38 /* Storyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storyboard.swift; sourceTree = "<group>"; };
-		F8096F2F27841F9200B71D38 /* MainVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainVC.swift; sourceTree = "<group>"; };
+		F8096F2F27841F9200B71D38 /* HomeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVC.swift; sourceTree = "<group>"; };
 		F8096F3127841FE100B71D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		F8096F33278420F100B71D38 /* TempView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempView.swift; sourceTree = "<group>"; };
 		F8096F35278420FA00B71D38 /* TempProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempProtocol.swift; sourceTree = "<group>"; };
@@ -58,6 +64,12 @@
 		F8096F412784214900B71D38 /* TempAppModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempAppModel.swift; sourceTree = "<group>"; };
 		F8096F432784221900B71D38 /* Xib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Xib.swift; sourceTree = "<group>"; };
 		F8096F452784247100B71D38 /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		F80A3E4C278C182100728E07 /* MainTabBar.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainTabBar.storyboard; sourceTree = "<group>"; };
+		F80A3E4E278C18BA00728E07 /* MainTBC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTBC.swift; sourceTree = "<group>"; };
+		F80A3E50278C1BCE00728E07 /* Feed.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
+		F80A3E52278C1C0C00728E07 /* Storage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Storage.storyboard; sourceTree = "<group>"; };
+		F80A3E54278C1C1F00728E07 /* StorageVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageVC.swift; sourceTree = "<group>"; };
+		F80A3E56278C1C2700728E07 /* FeedVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedVC.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -169,8 +181,8 @@
 		F8096F1B27841A3D00B71D38 /* Storyboards */ = {
 			isa = PBXGroup;
 			children = (
-				F8096F092784107D00B71D38 /* Main.storyboard */,
 				F8096F0E2784107E00B71D38 /* LaunchScreen.storyboard */,
+				F80A3E59278C239F00728E07 /* TabBar */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -194,7 +206,7 @@
 		F8096F1E27841DC100B71D38 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
-				F8096F2F27841F9200B71D38 /* MainVC.swift */,
+				F80A3E58278C22BA00728E07 /* TabBar */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -238,6 +250,28 @@
 				F8096F3F2784214000B71D38 /* TempCell.swift */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		F80A3E58278C22BA00728E07 /* TabBar */ = {
+			isa = PBXGroup;
+			children = (
+				F80A3E4E278C18BA00728E07 /* MainTBC.swift */,
+				F8096F2F27841F9200B71D38 /* HomeVC.swift */,
+				F80A3E54278C1C1F00728E07 /* StorageVC.swift */,
+				F80A3E56278C1C2700728E07 /* FeedVC.swift */,
+			);
+			path = TabBar;
+			sourceTree = "<group>";
+		};
+		F80A3E59278C239F00728E07 /* TabBar */ = {
+			isa = PBXGroup;
+			children = (
+				F80A3E4C278C182100728E07 /* MainTabBar.storyboard */,
+				F80A3E50278C1BCE00728E07 /* Feed.storyboard */,
+				F8096F092784107D00B71D38 /* Home.storyboard */,
+				F80A3E52278C1C0C00728E07 /* Storage.storyboard */,
+			);
+			path = TabBar;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -300,10 +334,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F80A3E4D278C182100728E07 /* MainTabBar.storyboard in Resources */,
 				F8096F102784107E00B71D38 /* LaunchScreen.storyboard in Resources */,
 				EBA77239278A2E14002958A5 /* Colors.xcassets in Resources */,
+				F80A3E51278C1BCE00728E07 /* Feed.storyboard in Resources */,
+				F80A3E53278C1C0C00728E07 /* Storage.storyboard in Resources */,
 				F8096F0D2784107E00B71D38 /* Assets.xcassets in Resources */,
-				F8096F0B2784107D00B71D38 /* Main.storyboard in Resources */,
+				F8096F0B2784107D00B71D38 /* Home.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -359,19 +396,22 @@
 				F8096F422784214900B71D38 /* TempAppModel.swift in Sources */,
 				F8096F3227841FE100B71D38 /* ViewController.swift in Sources */,
 				F8096F042784107D00B71D38 /* AppDelegate.swift in Sources */,
+				F80A3E55278C1C1F00728E07 /* StorageVC.swift in Sources */,
 				F8096F3A2784210A00B71D38 /* TempModel.swift in Sources */,
 				F8096F3C2784211D00B71D38 /* UIColor+Extension.swift in Sources */,
 				F8096F34278420F100B71D38 /* TempView.swift in Sources */,
 				F8096F2B27841F4100B71D38 /* Storyboard.swift in Sources */,
 				F8096F442784221900B71D38 /* Xib.swift in Sources */,
+				F80A3E4F278C18BA00728E07 /* MainTBC.swift in Sources */,
 				F8096F2627841F0900B71D38 /* TempFont.swift in Sources */,
 				F8096F402784214000B71D38 /* TempCell.swift in Sources */,
+				F80A3E57278C1C2700728E07 /* FeedVC.swift in Sources */,
 				F8096F36278420FA00B71D38 /* TempProtocol.swift in Sources */,
 				F8096F062784107D00B71D38 /* SceneDelegate.swift in Sources */,
 				F8096F382784210000B71D38 /* TempService.swift in Sources */,
 				F8096F3E2784213700B71D38 /* UIFont+Extension.swift in Sources */,
 				F8096F2927841F1E00B71D38 /* Const.swift in Sources */,
-				F8096F3027841F9200B71D38 /* MainVC.swift in Sources */,
+				F8096F3027841F9200B71D38 /* HomeVC.swift in Sources */,
 				F8096F462784247100B71D38 /* Notification.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -379,12 +419,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
-		F8096F092784107D00B71D38 /* Main.storyboard */ = {
+		F8096F092784107D00B71D38 /* Home.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
 				F8096F0A2784107D00B71D38 /* Base */,
 			);
-			name = Main.storyboard;
+			name = Home.storyboard;
 			sourceTree = "<group>";
 		};
 		F8096F0E2784107E00B71D38 /* LaunchScreen.storyboard */ = {

--- a/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
@@ -11,7 +11,10 @@ extension Const {
     /// Storyboard 의 name 을 상수로 관리합니다.
     struct Storyboard {
         struct Name {
-            static let main = "Main"
+            static let mainTabBar = "MainTabBar"
+            static let home = "Home"
+            static let feed = "Feed"
+            static let storage = "Storage"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
@@ -11,7 +11,10 @@ extension Const {
     /// ViewController 의 identifier 을 상수로 관리합니다.
     struct ViewController {
         struct Identifier {
-            static let main = "MainVC"
+            static let mainTabBar = "MainTBC"
+            static let home = "HomeVC"
+            static let feed = "FeedVC"
+            static let storage = "StorageVC"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Base.lproj/Home.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Base.lproj/Home.storyboard
@@ -8,10 +8,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--MainVC-->
+        <!--HomeVC-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="MainVC" id="BYZ-38-t0r" customClass="MainVC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="HomeVC" id="BYZ-38-t0r" customClass="HomeVC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Feed.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Feed.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--FeedVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="FeedVC" id="Y6W-OH-hqX" customClass="FeedVC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="20" y="66"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/MainTabBar.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/MainTabBar.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--MainTBC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="MainTBC" id="Y6W-OH-hqX" customClass="MainTBC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="20" y="85"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Storage.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Storage.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--StorageVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="StorageVC" id="Y6W-OH-hqX" customClass="StorageVC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="20" y="66"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.main, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.main
+        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar
         )
         // 코드베이스로 테스트할 때 다음과 같이 사용 가능합니다.
         // window?.rootViewController = MainVC()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -1,0 +1,17 @@
+//
+//  FeedVC.swift
+//  Spark-iOS
+//
+//  Created by kimhyungyu on 2022/01/10.
+//
+
+import UIKit
+
+class FeedVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+}

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MainVC: UIViewController {
+class HomeVC: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
@@ -1,0 +1,42 @@
+//
+//  MainTBC.swift
+//  Spark-iOS
+//
+//  Created by kimhyungyu on 2022/01/10.
+//
+
+import UIKit
+
+class MainTBC: UITabBarController {
+
+    // MARK: - View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setTabBar()
+    }
+}
+
+// MARK: - Methods
+
+extension MainTBC {
+    private func setTabBar() {
+        guard let feedVC = UIStoryboard(name: Const.Storyboard.Name.feed, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.feed) as? FeedVC,
+              let homeVC = UIStoryboard(name: Const.Storyboard.Name.home, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.home) as? HomeVC,
+              let storageVC = UIStoryboard(name: Const.Storyboard.Name.storage, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.storage) as? StorageVC else { return }
+        
+        feedVC.tabBarItem = UITabBarItem(title: "피드", image: UIImage(), selectedImage: UIImage())
+        
+        homeVC.tabBarItem = UITabBarItem(title: "홈", image: UIImage(), selectedImage: UIImage())
+        storageVC.tabBarItem = UITabBarItem(title: "보관함", image: UIImage(), selectedImage: UIImage())
+    
+        UITabBarItem.appearance().setTitleTextAttributes([NSAttributedString.Key.font: UIFont.systemFont(ofSize: 12)], for: .normal)
+        
+        setViewControllers([feedVC, homeVC, storageVC], animated: false)
+        
+        tabBar.tintColor = .sparkDarkPinkred
+        tabBar.itemPositioning = .centered
+        selectedIndex = 1
+    }
+}

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
@@ -26,10 +26,10 @@ extension MainTBC {
               let homeVC = UIStoryboard(name: Const.Storyboard.Name.home, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.home) as? HomeVC,
               let storageVC = UIStoryboard(name: Const.Storyboard.Name.storage, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.storage) as? StorageVC else { return }
         
-        feedVC.tabBarItem = UITabBarItem(title: "피드", image: UIImage(), selectedImage: UIImage())
+        feedVC.tabBarItem = UITabBarItem(title: "피드", image: UIImage(named: "icFeedInactive"), selectedImage: UIImage(named: "icFeedActive"))
         
-        homeVC.tabBarItem = UITabBarItem(title: "홈", image: UIImage(), selectedImage: UIImage())
-        storageVC.tabBarItem = UITabBarItem(title: "보관함", image: UIImage(), selectedImage: UIImage())
+        homeVC.tabBarItem = UITabBarItem(title: "홈", image: UIImage(named: "icHomeInactive"), selectedImage: UIImage(named: "icHomeActive"))
+        storageVC.tabBarItem = UITabBarItem(title: "보관함", image: UIImage(named: "icMyboxInactive"), selectedImage: UIImage(named: "icMyboxActive"))
     
         UITabBarItem.appearance().setTitleTextAttributes([NSAttributedString.Key.font: UIFont.systemFont(ofSize: 12)], for: .normal)
         

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
@@ -1,0 +1,17 @@
+//
+//  StorageVC.swift
+//  Spark-iOS
+//
+//  Created by kimhyungyu on 2022/01/10.
+//
+
+import UIKit
+
+class StorageVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#17

🌱 작업한 내용
- 피드, 홈, 보관함 탭바 구현
- 이미지 설정 코드 추가
- 폰트 크기설정.
> 폰트설정은 하지 않음.(#14 머지되면 수정예정)

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

- 제플린에서는 탭바 아이콘 사이 거리가 가까운데 커스텀하지 않는이상 가까워지지 않는듯 해여.. 이미지는 되는데 글자가.. 요거 일단 가져가고 나중에 얘기해봐야할듯 합니당!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|탭바|<img src="https://user-images.githubusercontent.com/69136340/148746455-ef636ff5-1145-4103-b469-f5f3aac61b4c.png" width ="250">|

## 📮 관련 이슈
- Resolved: #17
