### PR TITLE
[Feat] #23 - 스플래시, 로그인 뷰 구현

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		F82B2E0A278EBC4400219628 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		F82B2E0D278ED01F00219628 /* Splash.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Splash.storyboard; sourceTree = "<group>"; };
 		F82B2E11278F54CD00219628 /* SplashVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashVC.swift; sourceTree = "<group>"; };
+		F8368FAA278F5DFF00110B74 /* Spark-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Spark-iOS.entitlements"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +143,7 @@
 		F8096F022784107D00B71D38 /* Spark-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				F8368FAA278F5DFF00110B74 /* Spark-iOS.entitlements */,
 				F8096F18278410F600B71D38 /* Source */,
 				F8096F17278410E200B71D38 /* Resource */,
 			);
@@ -632,9 +634,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Spark-iOS/Spark-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4QG3GC35LA;
+				DEVELOPMENT_TEAM = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Spark-iOS/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Spark;
@@ -649,7 +652,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.Team-Sparker.Spark";
+				PRODUCT_BUNDLE_IDENTIFIER = com.TeamSparker.Spark;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -663,9 +666,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Spark-iOS/Spark-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 4QG3GC35LA;
+				DEVELOPMENT_TEAM = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Spark-iOS/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Spark;
@@ -680,7 +684,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.Team-Sparker.Spark";
+				PRODUCT_BUNDLE_IDENTIFIER = com.TeamSparker.Spark;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		F80A3E53278C1C0C00728E07 /* Storage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F80A3E52278C1C0C00728E07 /* Storage.storyboard */; };
 		F80A3E55278C1C1F00728E07 /* StorageVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80A3E54278C1C1F00728E07 /* StorageVC.swift */; };
 		F80A3E57278C1C2700728E07 /* FeedVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80A3E56278C1C2700728E07 /* FeedVC.swift */; };
+		F816F122278E1C760008ED00 /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F816F121278E1C760008ED00 /* Login.storyboard */; };
+		F816F125278E1C920008ED00 /* LoginVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F816F124278E1C920008ED00 /* LoginVC.swift */; };
+		F82B2E0B278EBC4400219628 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82B2E0A278EBC4400219628 /* UserDefaults.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -80,6 +83,9 @@
 		F80A3E52278C1C0C00728E07 /* Storage.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Storage.storyboard; sourceTree = "<group>"; };
 		F80A3E54278C1C1F00728E07 /* StorageVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageVC.swift; sourceTree = "<group>"; };
 		F80A3E56278C1C2700728E07 /* FeedVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedVC.swift; sourceTree = "<group>"; };
+		F816F121278E1C760008ED00 /* Login.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Login.storyboard; sourceTree = "<group>"; };
+		F816F124278E1C920008ED00 /* LoginVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVC.swift; sourceTree = "<group>"; };
+		F82B2E0A278EBC4400219628 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +182,7 @@
 				F8096F3127841FE100B71D38 /* ViewController.swift */,
 				F8096F432784221900B71D38 /* Xib.swift */,
 				F8096F452784247100B71D38 /* Notification.swift */,
+				F82B2E0A278EBC4400219628 /* UserDefaults.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -197,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				F8096F0E2784107E00B71D38 /* LaunchScreen.storyboard */,
+				F816F120278E1C550008ED00 /* Login */,
 				F80A3E59278C239F00728E07 /* TabBar */,
 			);
 			path = Storyboards;
@@ -221,6 +229,7 @@
 		F8096F1E27841DC100B71D38 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				F816F123278E1C800008ED00 /* Login */,
 				F80A3E58278C22BA00728E07 /* TabBar */,
 			);
 			path = ViewControllers;
@@ -289,6 +298,22 @@
 			path = TabBar;
 			sourceTree = "<group>";
 		};
+		F816F120278E1C550008ED00 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				F816F121278E1C760008ED00 /* Login.storyboard */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		F816F123278E1C800008ED00 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				F816F124278E1C920008ED00 /* LoginVC.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -351,6 +376,7 @@
 			files = (
 				F80A3E4D278C182100728E07 /* MainTabBar.storyboard in Resources */,
 				F8096F102784107E00B71D38 /* LaunchScreen.storyboard in Resources */,
+				F816F122278E1C760008ED00 /* Login.storyboard in Resources */,
 				2B9471F9278BE922005484C5 /* NotoSansKR-Bold.otf in Resources */,
 				2B9471FA278BE922005484C5 /* NotoSansKR-Medium.otf in Resources */,
 				2B9471FB278BE922005484C5 /* NotoSansKR-Regular.otf in Resources */,
@@ -415,6 +441,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8096F422784214900B71D38 /* TempAppModel.swift in Sources */,
+				F82B2E0B278EBC4400219628 /* UserDefaults.swift in Sources */,
 				F8096F3227841FE100B71D38 /* ViewController.swift in Sources */,
 				F8096F042784107D00B71D38 /* AppDelegate.swift in Sources */,
 				F80A3E55278C1C1F00728E07 /* StorageVC.swift in Sources */,
@@ -428,6 +455,7 @@
 				F80A3E57278C1C2700728E07 /* FeedVC.swift in Sources */,
 				F8096F36278420FA00B71D38 /* TempProtocol.swift in Sources */,
 				F8096F062784107D00B71D38 /* SceneDelegate.swift in Sources */,
+				F816F125278E1C920008ED00 /* LoginVC.swift in Sources */,
 				F8096F382784210000B71D38 /* TempService.swift in Sources */,
 				F8096F3E2784213700B71D38 /* UIFont+Extension.swift in Sources */,
 				F8096F2927841F1E00B71D38 /* Const.swift in Sources */,

--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		F816F122278E1C760008ED00 /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F816F121278E1C760008ED00 /* Login.storyboard */; };
 		F816F125278E1C920008ED00 /* LoginVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F816F124278E1C920008ED00 /* LoginVC.swift */; };
 		F82B2E0B278EBC4400219628 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82B2E0A278EBC4400219628 /* UserDefaults.swift */; };
+		F82B2E0E278ED01F00219628 /* Splash.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F82B2E0D278ED01F00219628 /* Splash.storyboard */; };
+		F82B2E12278F54CD00219628 /* SplashVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82B2E11278F54CD00219628 /* SplashVC.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -86,6 +88,8 @@
 		F816F121278E1C760008ED00 /* Login.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Login.storyboard; sourceTree = "<group>"; };
 		F816F124278E1C920008ED00 /* LoginVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVC.swift; sourceTree = "<group>"; };
 		F82B2E0A278EBC4400219628 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
+		F82B2E0D278ED01F00219628 /* Splash.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Splash.storyboard; sourceTree = "<group>"; };
+		F82B2E11278F54CD00219628 /* SplashVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashVC.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				F8096F0E2784107E00B71D38 /* LaunchScreen.storyboard */,
+				F82B2E0F278F54B000219628 /* Splash */,
 				F816F120278E1C550008ED00 /* Login */,
 				F80A3E59278C239F00728E07 /* TabBar */,
 			);
@@ -229,6 +234,7 @@
 		F8096F1E27841DC100B71D38 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				F82B2E10278F54C200219628 /* Splash */,
 				F816F123278E1C800008ED00 /* Login */,
 				F80A3E58278C22BA00728E07 /* TabBar */,
 			);
@@ -314,6 +320,22 @@
 			path = Login;
 			sourceTree = "<group>";
 		};
+		F82B2E0F278F54B000219628 /* Splash */ = {
+			isa = PBXGroup;
+			children = (
+				F82B2E0D278ED01F00219628 /* Splash.storyboard */,
+			);
+			path = Splash;
+			sourceTree = "<group>";
+		};
+		F82B2E10278F54C200219628 /* Splash */ = {
+			isa = PBXGroup;
+			children = (
+				F82B2E11278F54CD00219628 /* SplashVC.swift */,
+			);
+			path = Splash;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -382,6 +404,7 @@
 				2B9471FB278BE922005484C5 /* NotoSansKR-Regular.otf in Resources */,
 				EBA77239278A2E14002958A5 /* Colors.xcassets in Resources */,
 				2B947204278CB00E005484C5 /* Futura Medium Italic.otf in Resources */,
+				F82B2E0E278ED01F00219628 /* Splash.storyboard in Resources */,
 				F80A3E51278C1BCE00728E07 /* Feed.storyboard in Resources */,
 				2B947203278CB00E005484C5 /* Futura Medium.otf in Resources */,
 				F80A3E53278C1C0C00728E07 /* Storage.storyboard in Resources */,
@@ -458,6 +481,7 @@
 				F816F125278E1C920008ED00 /* LoginVC.swift in Sources */,
 				F8096F382784210000B71D38 /* TempService.swift in Sources */,
 				F8096F3E2784213700B71D38 /* UIFont+Extension.swift in Sources */,
+				F82B2E12278F54CD00219628 /* SplashVC.swift in Sources */,
 				F8096F2927841F1E00B71D38 /* Const.swift in Sources */,
 				F8096F3027841F9200B71D38 /* HomeVC.swift in Sources */,
 				F8096F462784247100B71D38 /* Notification.swift in Sources */,

--- a/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
@@ -16,6 +16,7 @@ extension Const {
             static let feed = "Feed"
             static let storage = "Storage"
             static let login = "Login"
+            static let splash = "Splash"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
@@ -15,6 +15,7 @@ extension Const {
             static let home = "Home"
             static let feed = "Feed"
             static let storage = "Storage"
+            static let login = "Login"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Constants/UserDefaults.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/UserDefaults.swift
@@ -10,5 +10,6 @@ import Foundation
 extension Const {
     struct UserDefaultsKey {
         static let isAppleLogin = "isAppleLogin"
+        static let isOnboarding = "isOnboarding"
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Constants/UserDefaults.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/UserDefaults.swift
@@ -1,0 +1,14 @@
+//
+//  UserDefaults.swift
+//  Spark-iOS
+//
+//  Created by kimhyungyu on 2022/01/12.
+//
+
+import Foundation
+
+extension Const {
+    struct UserDefaultsKey {
+        static let isAppleLogin = "isAppleLogin"
+    }
+}

--- a/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
@@ -16,6 +16,7 @@ extension Const {
             static let feed = "FeedVC"
             static let storage = "StorageVC"
             static let login = "LoginVC"
+            static let splash = "SplashVC"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
@@ -15,6 +15,7 @@ extension Const {
             static let home = "HomeVC"
             static let feed = "FeedVC"
             static let storage = "StorageVC"
+            static let login = "LoginVC"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Info.plist
+++ b/Spark-iOS/Spark-iOS/Resource/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakaod51e83bca123750446afc70ab65225b9</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Futura Bold.otf</string>

--- a/Spark-iOS/Spark-iOS/Resource/Info.plist
+++ b/Spark-iOS/Spark-iOS/Resource/Info.plist
@@ -13,6 +13,11 @@
 			</array>
 		</dict>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Futura Bold.otf</string>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Base.lproj/LaunchScreen.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Base.lproj/LaunchScreen.storyboard
@@ -22,11 +22,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bgSplash" translatesAutoresizingMaskIntoConstraints="NO" id="GTm-WJ-PEg">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                            </imageView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoWhite" highlighted="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fVy-io-6CN">
-                                <rect key="frame" x="125" y="276" width="164" height="84"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="bgSplash" translatesAutoresizingMaskIntoConstraints="NO" id="GTm-WJ-PEg">
+                                <rect key="frame" x="0.0" y="-34" width="414" height="930"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="친구와 함께 66일간 습관을!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Axh-4z-gk8">
                                 <rect key="frame" x="104" y="767.5" width="206.5" height="26.5"/>
@@ -34,6 +31,9 @@
                                 <color key="textColor" name="sparkWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoWhite" highlighted="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fVy-io-6CN">
+                                <rect key="frame" x="125" y="276" width="164" height="84"/>
+                            </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -51,7 +51,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="53" y="375"/>
+            <point key="canvasLocation" x="52.173913043478265" y="375"/>
         </scene>
     </scenes>
     <resources>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Base.lproj/LaunchScreen.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Base.lproj/LaunchScreen.storyboard
@@ -1,20 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="NotoSansKR-Medium.otf">
+            <string>NotoSansKR-Medium</string>
+        </array>
+    </customFonts>
     <scenes>
         <!--View Controller-->
         <scene sceneID="EHf-IW-A2E">
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bgSplash" translatesAutoresizingMaskIntoConstraints="NO" id="GTm-WJ-PEg">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                            </imageView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoWhite" highlighted="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fVy-io-6CN">
+                                <rect key="frame" x="125" y="276" width="164" height="84"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="친구와 함께 66일간 습관을!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Axh-4z-gk8">
+                                <rect key="frame" x="104" y="767.5" width="206.5" height="26.5"/>
+                                <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="18"/>
+                                <color key="textColor" name="sparkWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Axh-4z-gk8" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="4B8-Vs-xVO"/>
+                            <constraint firstItem="GTm-WJ-PEg" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="LzU-Rp-LcH"/>
+                            <constraint firstAttribute="bottom" secondItem="Axh-4z-gk8" secondAttribute="bottom" constant="102" id="S4r-DX-UiL"/>
+                            <constraint firstAttribute="bottom" secondItem="GTm-WJ-PEg" secondAttribute="bottom" id="bn6-lu-k1A"/>
+                            <constraint firstItem="fVy-io-6CN" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="caJ-3t-xnx"/>
+                            <constraint firstItem="fVy-io-6CN" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="232" id="rca-J7-6Fm"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="GTm-WJ-PEg" secondAttribute="trailing" id="uwh-Y3-sQi"/>
+                            <constraint firstItem="GTm-WJ-PEg" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="wOc-Ep-YUu"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -22,4 +54,14 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="bgSplash" width="375" height="812"/>
+        <image name="logoWhite" width="164" height="84"/>
+        <namedColor name="sparkWhite">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Base.lproj/LaunchScreen.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Base.lproj/LaunchScreen.storyboard
@@ -25,8 +25,8 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="bgSplash" translatesAutoresizingMaskIntoConstraints="NO" id="GTm-WJ-PEg">
                                 <rect key="frame" x="0.0" y="-34" width="414" height="930"/>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="친구와 함께 66일간 습관을!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Axh-4z-gk8">
-                                <rect key="frame" x="104" y="767.5" width="206.5" height="26.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="친구와 함께 66일간 습관을!" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Axh-4z-gk8">
+                                <rect key="frame" x="104" y="767.5" width="206" height="26.5"/>
                                 <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="18"/>
                                 <color key="textColor" name="sparkWhite"/>
                                 <nil key="highlightedColor"/>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Login/Login.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Login/Login.storyboard
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--LoginVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="LoginVC" id="Y6W-OH-hqX" customClass="LoginVC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bgLogin" translatesAutoresizingMaskIntoConstraints="NO" id="3aV-hw-Imz">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8d-e3-AlI">
+                                <rect key="frame" x="186" y="829" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="khA-Ly-iRg">
+                                <rect key="frame" x="192" y="767" width="30" height="34"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <connections>
+                                    <action selector="touchAppleLoginButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="PK7-na-bT4"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fa3-GQ-rb5">
+                                <rect key="frame" x="192" y="717" width="30" height="34"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <connections>
+                                    <action selector="touchKakaoLoginButton:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="gqt-I8-Ond"/>
+                                </connections>
+                            </button>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoWhite" translatesAutoresizingMaskIntoConstraints="NO" id="zJk-BV-13w">
+                                <rect key="frame" x="125" y="276" width="164" height="84"/>
+                            </imageView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="khA-Ly-iRg" firstAttribute="top" secondItem="fa3-GQ-rb5" secondAttribute="bottom" constant="16" id="9CA-s2-itZ"/>
+                            <constraint firstItem="zJk-BV-13w" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="232" id="DKO-BL-kB1"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="3aV-hw-Imz" secondAttribute="trailing" id="Naf-4V-ivY"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="i8d-e3-AlI" secondAttribute="bottom" constant="12" id="OnB-pc-AhS"/>
+                            <constraint firstItem="3aV-hw-Imz" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="TTs-US-nib"/>
+                            <constraint firstAttribute="bottom" secondItem="3aV-hw-Imz" secondAttribute="bottom" id="Tfd-ln-LC9"/>
+                            <constraint firstItem="fa3-GQ-rb5" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="iZY-XD-75O"/>
+                            <constraint firstItem="i8d-e3-AlI" firstAttribute="top" secondItem="khA-Ly-iRg" secondAttribute="bottom" constant="28" id="ljW-OR-CHN"/>
+                            <constraint firstItem="3aV-hw-Imz" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="oCk-qS-gZA"/>
+                            <constraint firstItem="i8d-e3-AlI" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="pYh-5I-Bi4"/>
+                            <constraint firstItem="khA-Ly-iRg" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="saB-wL-w9S"/>
+                            <constraint firstItem="zJk-BV-13w" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="yRo-6c-xBa"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="appleLoginButton" destination="khA-Ly-iRg" id="w17-Ax-rSf"/>
+                        <outlet property="kakaoLoginButton" destination="fa3-GQ-rb5" id="QGH-xs-pfg"/>
+                        <outlet property="loginLabel" destination="i8d-e3-AlI" id="e75-nt-IYO"/>
+                        <outlet property="logoImageView" destination="zJk-BV-13w" id="oPn-5o-YxL"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="139"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="bgLogin" width="375" height="812"/>
+        <image name="logoWhite" width="164" height="84"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Splash/Splash.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Splash/Splash.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="NotoSansKR-Medium.otf">
+            <string>NotoSansKR-Medium</string>
+        </array>
+    </customFonts>
+    <scenes>
+        <!--SplashVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="SplashVC" id="Y6W-OH-hqX" customClass="SplashVC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bgSplash" translatesAutoresizingMaskIntoConstraints="NO" id="Vcg-Gk-HaB">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                            </imageView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoWhite" translatesAutoresizingMaskIntoConstraints="NO" id="nb8-nR-lxo">
+                                <rect key="frame" x="125" y="276" width="164" height="84"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="친구와 함께 66일간 습관을!" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zvg-KI-cdU">
+                                <rect key="frame" x="104" y="767.5" width="206.5" height="26.5"/>
+                                <fontDescription key="fontDescription" name="NotoSansKR-Medium" family="Noto Sans KR" pointSize="18"/>
+                                <color key="textColor" name="sparkWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="nb8-nR-lxo" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="232" id="40d-Sp-LbD"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Vcg-Gk-HaB" secondAttribute="trailing" id="FGM-n6-Cmg"/>
+                            <constraint firstItem="nb8-nR-lxo" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="Jy2-NE-PsM"/>
+                            <constraint firstAttribute="bottom" secondItem="zvg-KI-cdU" secondAttribute="bottom" constant="102" id="PE9-tf-a6E"/>
+                            <constraint firstItem="Vcg-Gk-HaB" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="h7a-3Y-Mrz"/>
+                            <constraint firstItem="Vcg-Gk-HaB" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="jFu-Rs-X4A"/>
+                            <constraint firstAttribute="bottom" secondItem="Vcg-Gk-HaB" secondAttribute="bottom" id="k94-Q7-TpB"/>
+                            <constraint firstItem="zvg-KI-cdU" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="rPx-IS-chA"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-19" y="63"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="bgSplash" width="375" height="812"/>
+        <image name="logoWhite" width="164" height="84"/>
+        <namedColor name="sparkWhite">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -16,7 +16,7 @@ import KakaoSDKUser
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var isLogin = false
-    // TODO: - 키체인 넣기
+    // TODO: - 엑세스 토큰 유저 아이디 키체인 넣기
     var accessToken = ""
     var userID = ""
 

--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -5,30 +5,78 @@
 //  Created by kimhyungyu on 2022/01/04.
 //
 
+import AuthenticationServices
 import UIKit
+
+import KakaoSDKAuth
+import KakaoSDKCommon
+import KakaoSDKUser
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
+    var isLogin = false
+    // TODO: - 키체인 넣기
+    var accessToken = ""
+    var userID = ""
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        KakaoSDK.initSDK(appKey: "d51e83bca123750446afc70ab65225b9")
+        
+        if accessToken != nil {
+            if UserDefaults.standard.bool(forKey: Const.UserDefaultsKey.isAppleLogin) {
+                // 애플 로그인으로 연동되어 있을 때, -> 애플 ID와의 연동상태 확인 로직
+                let appleIDProvider = ASAuthorizationAppleIDProvider()
+                appleIDProvider.getCredentialState(forUserID: userID) { (credentialState, error) in
+                    switch credentialState {
+                    case .authorized:
+                        print("해당 ID는 연동되어있습니다.")
+                        self.isLogin = true
+                    case .revoked:
+                        print("해당 ID는 연동되어있지않습니다.")
+                        self.isLogin = false
+                    case .notFound:
+                        print("해당 ID를 찾을 수 없습니다.")
+                        self.isLogin = false
+                    default:
+                        break
+                    }
+                }
+            } else {
+                if AuthApi.hasToken() {
+                    UserApi.shared.accessTokenInfo { (_, error) in
+                        if let error = error {
+                            if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true {
+                                self.isLogin = false
+                            }
+                        } else {
+                            self.isLogin = true
+                        }
+                    }
+                } else {
+                    self.isLogin = false
+                }
+            }
+        } else {
+            self.isLogin = false
+        }
+
+        // 앱 실행 중 애플 ID 강제로 연결 취소 시
+        NotificationCenter.default.addObserver(forName: ASAuthorizationAppleIDProvider.credentialRevokedNotification, object: nil, queue: nil) { (Notification) in
+            print("Revoked Notification")
+            self.isLogin = false
+        }
+        
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
 

--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -50,14 +50,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                 self.isLogin = false
                             }
                         } else {
+                            // 토큰 유효성 확인한 경우.
                             self.isLogin = true
                         }
                     }
                 } else {
+                    // 유효한 토큰이 없는 경우.
                     self.isLogin = false
                 }
             }
         } else {
+            // access token 이 없는 경우.
             self.isLogin = false
         }
 

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -7,22 +7,31 @@
 
 import UIKit
 
+import KakaoSDKAuth
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar
+        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login
         )
         // 코드베이스로 테스트할 때 다음과 같이 사용 가능합니다.
         // window?.rootViewController = MainVC()
         
         window?.makeKeyAndVisible()
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login
+        window?.rootViewController = UIStoryboard(name: Const.Storyboard.Name.splash, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.splash
         )
         // 코드베이스로 테스트할 때 다음과 같이 사용 가능합니다.
         // window?.rootViewController = MainVC()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Login/LoginVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Login/LoginVC.swift
@@ -48,8 +48,7 @@ extension LoginVC {
         loginLabel.text = "로그인 시 이용약관과 개인정보 처리 방침에 동의하게 됩니다."
         loginLabel.textColor = .sparkWhite
         
-        // TODO: - 로그인 라벨 폰트 적용
-//        loginLabel.font = .
+        loginLabel.font = .krMediumFont(ofSize: 12)
         
         kakaoLoginButton.setImage(UIImage(named: "btnKakaoLogin"), for: .normal)
         appleLoginButton.setImage(UIImage(named: "btnAppleLogin"), for: .normal)
@@ -118,6 +117,7 @@ extension LoginVC {
     private func presentToMainTabBar() {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
         nextVC.modalPresentationStyle = .fullScreen
+        nextVC.modalTransitionStyle = .crossDissolve
         
         present(nextVC, animated: true, completion: nil)
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Login/LoginVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Login/LoginVC.swift
@@ -126,9 +126,12 @@ extension LoginVC {
 // MARK: - Network
 
 extension LoginVC {
+    
+    // TODO: - 회원가입 로직
+    
     private func signupWithAPI(userID: String) {
         
-        // TODO: -
+        // TODO: - 엑세스 토큰 키체인에 등록하고 화면전환
         
         presentToMainTabBar()
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Login/LoginVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Login/LoginVC.swift
@@ -1,0 +1,120 @@
+//
+//  LoginVC.swift
+//  Spark-iOS
+//
+//  Created by kimhyungyu on 2022/01/12.
+//
+
+import UIKit
+
+import KakaoSDKUser
+
+class LoginVC: UIViewController {
+
+    // MARK: - Properties
+    
+    // MARK: - @IBOutlet Properties
+    
+    @IBOutlet weak var loginLabel: UILabel!
+    @IBOutlet weak var kakaoLoginButton: UIButton!
+    @IBOutlet weak var appleLoginButton: UIButton!
+    @IBOutlet weak var logoImageView: UIImageView!
+    
+    
+    // MARK: - View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+    }
+    
+    // MARK: - @IBOutlet Action
+    
+    @IBAction func touchAppleLoginButton(_ sender: Any) {
+    }
+    
+    @IBAction func touchKakaoLoginButton(_ sender: Any) {
+        signupWithKakao()
+    }
+}
+
+// MARK: - Methods
+
+extension LoginVC {
+    private func setUI() {
+        loginLabel.text = "로그인 시 이용약관과 개인정보 처리 방침에 동의하게 됩니다."
+        loginLabel.textColor = .sparkWhite
+        
+        // TODO: - 로그인 라벨 폰트 적용
+//        loginLabel.font = .
+        
+        kakaoLoginButton.setImage(UIImage(named: "btnKakaoLogin"), for: .normal)
+        appleLoginButton.setImage(UIImage(named: "btnAppleLogin"), for: .normal)
+    }
+    
+    
+    private func signupWithKakao() {
+        if (UserApi.isKakaoTalkLoginAvailable()) {
+            loginWithKakaoApp()
+        }
+        else {
+            loginWithWeb()
+        }
+    }
+    
+    private func loginWithKakaoApp() {
+        UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+            if let error = error {
+                print(error)
+            } else {
+                print("loginWithKakaoApp() success.")
+                
+                self.getUserID()
+            }
+        }
+    }
+    
+    private func loginWithWeb() {
+        UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
+            if let error = error {
+                print(error)
+            } else {
+                print("loginWithKakaoAccount() success.")
+                
+                self.getUserID()
+            }
+        }
+    }
+    
+    private func getUserID() {
+        UserApi.shared.me {(user, error) in
+            if let error = error {
+                print(error)
+            } else {
+                if let userID = user?.id {
+                    self.signupWithAPI(userID: Int(userID))
+                    
+                    // TODO: - 키체인
+                    
+                }
+            }
+        }
+    }
+    
+    private func presentToMainTabBar() {
+        guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
+        nextVC.modalPresentationStyle = .fullScreen
+        
+        present(nextVC, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Network
+
+extension LoginVC {
+    private func signupWithAPI(userID: Int) {
+        // TODO: - 회원가입 성공 시 화면전환
+        presentToMainTabBar()
+    }
+}

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
@@ -1,0 +1,61 @@
+//
+//  SplashVC.swift
+//  Spark-iOS
+//
+//  Created by kimhyungyu on 2022/01/13.
+//
+
+import UIKit
+
+class SplashVC: UIViewController {
+
+    // MARK: - Properties
+    
+    private weak var appDelegate = UIApplication.shared.delegate as? AppDelegate
+ 
+    // MARK: - View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+         super.viewWillAppear(animated)
+        
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1) {
+            if self.appDelegate?.isLogin == true {
+                self.presentToMain()
+            } else {
+                
+                // FIXME: - 온보딩 만들면 적용하기
+//
+//                if UserDefaults.standard.object(forKey: Const.UserDefaultsKey.isOnboarding) != nil {
+                    self.presentToLogin()
+//                } else {
+//                    self.presentToOnboarding()
+//                }
+            }
+        }
+    }
+    
+    // MARK: - Functions
+    
+    private func presentToMain() {
+        guard let mainVC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
+        mainVC.modalPresentationStyle = .fullScreen
+        mainVC.modalTransitionStyle = .crossDissolve
+        self.present(mainVC, animated: true, completion: nil)
+    }
+    
+    private func presentToLogin() {
+        guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
+        loginVC.modalPresentationStyle = .fullScreen
+        loginVC.modalTransitionStyle = .crossDissolve
+        self.present(loginVC, animated: true, completion: nil)
+    }
+    
+    private func presentToOnboarding() {
+        // TODO: - 온보딩 뷰 화면전환
+    }
+}

--- a/Spark-iOS/Spark-iOS/Spark-iOS.entitlements
+++ b/Spark-iOS/Spark-iOS/Spark-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#23

🌱 작업한 내용
- 스플래시 화면 구현
- 스플래시뷰에서 온보딩, 메인, 로그인 화면전환 분기 처리
- 로그인뷰 구현
- 로그인뷰 카카오, 애플 로그인 구현

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- appdelegate 에서 카카오와 애플의 로그인 유효성 여부를 판단하고 splash 뷰에서 appdelegate 의 변수를 가져와서 화면전환하는 용도입니다.
- splash 에서 viewWillAppear 로 화면전환을 하는 이유는 viewDidLoad 에서 진행하면 화면이 다그려지지 않았는데 화면전환한다고 에러를 뱉습니당! 그래서 1초를 줘서 이쁜 스플래쉬를 보여주고~ 화면전환~


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src="https://user-images.githubusercontent.com/69136340/149206865-12d83259-2120-41b0-829c-3a9b41c6b18c.jpeg" width ="250">|


## 📮 관련 이슈
- Resolved: #23
