### PR TITLE
[Feat] #113 - 케이스별 dialogue 구현

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		EB625E96278F8E7200C43DE9 /* MoreStorageCVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = EB625E94278F8E7200C43DE9 /* MoreStorageCVC.xib */; };
 		EB625E99278F8EF200C43DE9 /* StorageMore.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EB625E98278F8EF200C43DE9 /* StorageMore.storyboard */; };
 		EB874AE82796FBD5000DD20B /* FeedCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBED1382795F4500052CA5C /* FeedCellDelegate.swift */; };
+		EB874AEB279706FC000DD20B /* DialogueVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB874AEA279706FC000DD20B /* DialogueVC.swift */; };
+		EB874AEE2797071C000DD20B /* Dialogue.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EB874AED2797071C000DD20B /* Dialogue.storyboard */; };
 		EB9C507D27922F2E00588155 /* LineAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C507C27922F2E00588155 /* LineAnimationView.swift */; };
 		EB9C50842792A61D00588155 /* HabitAuthVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C50832792A61D00588155 /* HabitAuthVC.swift */; };
 		EB9C50882792A67B00588155 /* HabitAuth.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EB9C50872792A67B00588155 /* HabitAuth.storyboard */; };
@@ -189,6 +191,8 @@
 		EB625E93278F8E7200C43DE9 /* MoreStorageCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreStorageCVC.swift; sourceTree = "<group>"; };
 		EB625E94278F8E7200C43DE9 /* MoreStorageCVC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MoreStorageCVC.xib; sourceTree = "<group>"; };
 		EB625E98278F8EF200C43DE9 /* StorageMore.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = StorageMore.storyboard; sourceTree = "<group>"; };
+		EB874AEA279706FC000DD20B /* DialogueVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogueVC.swift; sourceTree = "<group>"; };
+		EB874AED2797071C000DD20B /* Dialogue.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Dialogue.storyboard; sourceTree = "<group>"; };
 		EB9C507C27922F2E00588155 /* LineAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineAnimationView.swift; sourceTree = "<group>"; };
 		EB9C50832792A61D00588155 /* HabitAuthVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HabitAuthVC.swift; sourceTree = "<group>"; };
 		EB9C50872792A67B00588155 /* HabitAuth.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = HabitAuth.storyboard; sourceTree = "<group>"; };
@@ -524,6 +528,22 @@
 			path = CodeJoin;
 			sourceTree = "<group>";
 		};
+		EB874AE9279706DB000DD20B /* Dialogue */ = {
+			isa = PBXGroup;
+			children = (
+				EB874AEA279706FC000DD20B /* DialogueVC.swift */,
+			);
+			path = Dialogue;
+			sourceTree = "<group>";
+		};
+		EB874AEC2797070B000DD20B /* Dialogue */ = {
+			isa = PBXGroup;
+			children = (
+				EB874AED2797071C000DD20B /* Dialogue.storyboard */,
+			);
+			path = Dialogue;
+			sourceTree = "<group>";
+		};
 		EB9C50822792A5C600588155 /* HabitRoom */ = {
 			isa = PBXGroup;
 			children = (
@@ -695,6 +715,7 @@
 				EBA93A80279080FC009AE771 /* CodeJoin */,
 				2B9C6BC72792777900CD914F /* GoalWriting */,
 				EB9C50862792A65C00588155 /* HabitRoom */,
+				EB874AEC2797070B000DD20B /* Dialogue */,
 				2BE5D80327930743007A544D /* Auth */,
 			);
 			path = Storyboards;
@@ -728,6 +749,7 @@
 				EB625E9A2790792F00C43DE9 /* CodeJoin */,
 				2B9C6BCC279277F500CD914F /* GoalWriting */,
 				EB9C50822792A5C600588155 /* HabitRoom */,
+				EB874AE9279706DB000DD20B /* Dialogue */,
 				2BE5D80627930774007A544D /* Auth */,
 			);
 			path = ViewControllers;
@@ -965,6 +987,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EB625E84278F273200C43DE9 /* FailStorageCVC.xib in Resources */,
+				EB874AEE2797071C000DD20B /* Dialogue.storyboard in Resources */,
 				F8C14A9C2795094800498687 /* HomeEmptyCVC.xib in Resources */,
 				2B9852092790ACF000CE40A7 /* CreateAuth.storyboard in Resources */,
 				F80A3E4D278C182100728E07 /* MainTabBar.storyboard in Resources */,
@@ -1105,6 +1128,7 @@
 				EBEA38372794B34300B5736A /* CodeJoinCheck.swift in Sources */,
 				F8096F2B27841F4100B71D38 /* Storyboard.swift in Sources */,
 				2BC17270278F54DB00BA3029 /* WaitingVC.swift in Sources */,
+				EB874AEB279706FC000DD20B /* DialogueVC.swift in Sources */,
 				EB9C508A2792A86D00588155 /* CompleteAuthVC.swift in Sources */,
 				2BBED13027956C9F0052CA5C /* Feed.swift in Sources */,
 				EBE90FCE2795C23A00157075 /* MyRoomCerti.swift in Sources */,

--- a/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
@@ -30,6 +30,7 @@ extension Const {
             static let authTimer = "AuthTimer"
             static let resetPopup = "ResetPopup"
             static let sendSpark = "SendSpark"
+            static let dialogue = "Dialogue"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
@@ -30,6 +30,7 @@ extension Const {
             static let authTimer = "AuthTimerVC"
             static let resetPopup = "ResetPopupVC"
             static let sendSpark = "SendSparkVC"
+            static let dialogue = "DialogueVC"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
@@ -138,7 +138,7 @@
                         <outlet property="cancelButton" destination="TSw-JK-bjt" id="GU4-Ux-8xJ"/>
                         <outlet property="cancelLabel" destination="f6E-dr-Sp0" id="KDB-BU-Rdt"/>
                         <outlet property="cancelView" destination="Phi-9Q-ATe" id="f5O-BR-EkB"/>
-                        <outlet property="dialogueVIew" destination="j4s-M0-BpU" id="QDA-m8-kzd"/>
+                        <outlet property="dialogueView" destination="j4s-M0-BpU" id="AGH-Ld-Imj"/>
                         <outlet property="guideLabel" destination="XIe-ns-Hlq" id="QgI-sD-FZc"/>
                         <outlet property="resetOrExitButton" destination="VGC-GZ-g7L" id="CUe-BD-UCK"/>
                         <outlet property="resetOrExitLabel" destination="w5g-YB-25v" id="FjM-3Y-pPn"/>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,16 +17,117 @@
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j4s-M0-BpU">
+                                <rect key="frame" x="20" y="404.5" width="374" height="97"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XIe-ns-Hlq">
+                                        <rect key="frame" x="187" y="25" width="0.0" height="0.0"/>
+                                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="0.0"/>
+                                        <color key="textColor" name="sparkBlack"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="njG-Fw-vJ6">
+                                        <rect key="frame" x="0.0" y="50" width="374" height="47"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Phi-9Q-ATe">
+                                                <rect key="frame" x="0.0" y="0.0" width="186.5" height="47"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="취소" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f6E-dr-Sp0">
+                                                        <rect key="frame" x="78.5" y="13.5" width="29.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="f6E-dr-Sp0" firstAttribute="centerX" secondItem="Phi-9Q-ATe" secondAttribute="centerX" id="V6i-Lk-Fs4"/>
+                                                    <constraint firstItem="f6E-dr-Sp0" firstAttribute="centerY" secondItem="Phi-9Q-ATe" secondAttribute="centerY" id="VOd-ge-b1Y"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MbD-UA-VmY">
+                                                <rect key="frame" x="186.5" y="0.0" width="1" height="47"/>
+                                                <color key="backgroundColor" name="sparkLightGray"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="1" id="EdX-re-rJs"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3Dc-fw-AHA">
+                                                <rect key="frame" x="187.5" y="0.0" width="186.5" height="47"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="나가기" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w5g-YB-25v">
+                                                        <rect key="frame" x="71" y="13.5" width="44.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="w5g-YB-25v" firstAttribute="centerY" secondItem="3Dc-fw-AHA" secondAttribute="centerY" id="PWl-Km-I9U"/>
+                                                    <constraint firstItem="w5g-YB-25v" firstAttribute="centerX" secondItem="3Dc-fw-AHA" secondAttribute="centerX" id="cFh-2O-O1j"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <color key="backgroundColor" name="sparkWhite"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="47" id="mpQ-vD-X5c"/>
+                                            <constraint firstItem="Phi-9Q-ATe" firstAttribute="width" secondItem="3Dc-fw-AHA" secondAttribute="width" id="o6S-Y0-r2R"/>
+                                        </constraints>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8b8-8n-sjq">
+                                        <rect key="frame" x="0.0" y="49" width="374" height="1"/>
+                                        <color key="backgroundColor" name="sparkLightGray"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="bux-Uf-rzy"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" name="sparkWhite"/>
+                                <constraints>
+                                    <constraint firstItem="njG-Fw-vJ6" firstAttribute="top" secondItem="XIe-ns-Hlq" secondAttribute="bottom" constant="25" id="7uM-XE-jz1"/>
+                                    <constraint firstItem="njG-Fw-vJ6" firstAttribute="leading" secondItem="j4s-M0-BpU" secondAttribute="leading" id="CKx-9c-PgY"/>
+                                    <constraint firstItem="XIe-ns-Hlq" firstAttribute="top" secondItem="j4s-M0-BpU" secondAttribute="top" constant="25" id="G74-xG-Gh4"/>
+                                    <constraint firstAttribute="trailing" secondItem="8b8-8n-sjq" secondAttribute="trailing" id="JzT-ds-IE4"/>
+                                    <constraint firstItem="njG-Fw-vJ6" firstAttribute="top" secondItem="8b8-8n-sjq" secondAttribute="bottom" id="N5E-zH-rcE"/>
+                                    <constraint firstAttribute="bottom" secondItem="njG-Fw-vJ6" secondAttribute="bottom" id="NMD-Ej-ZPn"/>
+                                    <constraint firstItem="XIe-ns-Hlq" firstAttribute="centerX" secondItem="j4s-M0-BpU" secondAttribute="centerX" id="OvQ-D4-Tug"/>
+                                    <constraint firstAttribute="trailing" secondItem="njG-Fw-vJ6" secondAttribute="trailing" id="f5y-BF-uGr"/>
+                                    <constraint firstItem="8b8-8n-sjq" firstAttribute="leading" secondItem="j4s-M0-BpU" secondAttribute="leading" id="stw-zs-fFP"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="j4s-M0-BpU" secondAttribute="trailing" constant="20" id="5M3-vZ-vKG"/>
+                            <constraint firstItem="j4s-M0-BpU" firstAttribute="centerY" secondItem="vDu-zF-Fre" secondAttribute="centerY" id="NhE-6X-5nj"/>
+                            <constraint firstItem="j4s-M0-BpU" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="rXR-2e-SuG"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="cancelLabel" destination="f6E-dr-Sp0" id="KDB-BU-Rdt"/>
+                        <outlet property="dialogueVIew" destination="j4s-M0-BpU" id="QDA-m8-kzd"/>
+                        <outlet property="guideLabel" destination="XIe-ns-Hlq" id="QgI-sD-FZc"/>
+                        <outlet property="resetOrExitLabel" destination="w5g-YB-25v" id="FjM-3Y-pPn"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="78" y="133"/>
+            <point key="canvasLocation" x="76.811594202898561" y="132.58928571428572"/>
         </scene>
     </scenes>
     <resources>
+        <namedColor name="sparkBlack">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="sparkLightGray">
+            <color red="0.92900002002716064" green="0.92900002002716064" blue="0.93300002813339233" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="sparkWhite">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
@@ -27,7 +27,7 @@
                                         <color key="textColor" name="sparkBlack"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="njG-Fw-vJ6">
+                                    <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="njG-Fw-vJ6">
                                         <rect key="frame" x="0.0" y="50" width="374" height="47"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Phi-9Q-ATe">
@@ -70,8 +70,10 @@
                                                 </constraints>
                                             </view>
                                         </subviews>
-                                        <color key="backgroundColor" name="sparkWhite"/>
+                                        <color key="backgroundColor" name="sparkLightGray"/>
                                         <constraints>
+                                            <constraint firstItem="3Dc-fw-AHA" firstAttribute="height" secondItem="njG-Fw-vJ6" secondAttribute="height" id="8mD-uG-hRn"/>
+                                            <constraint firstItem="Phi-9Q-ATe" firstAttribute="height" secondItem="njG-Fw-vJ6" secondAttribute="height" id="Y7Q-SJ-OR5"/>
                                             <constraint firstAttribute="height" constant="47" id="mpQ-vD-X5c"/>
                                             <constraint firstItem="Phi-9Q-ATe" firstAttribute="width" secondItem="3Dc-fw-AHA" secondAttribute="width" id="o6S-Y0-r2R"/>
                                         </constraints>
@@ -97,20 +99,50 @@
                                     <constraint firstItem="8b8-8n-sjq" firstAttribute="leading" secondItem="j4s-M0-BpU" secondAttribute="leading" id="stw-zs-fFP"/>
                                 </constraints>
                             </view>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TSw-JK-bjt">
+                                <rect key="frame" x="20" y="454" width="186.5" height="48"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal">
+                                    <color key="titleColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VGC-GZ-g7L">
+                                <rect key="frame" x="207.5" y="454.5" width="186.5" height="47"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal">
+                                    <color key="titleColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="j4s-M0-BpU" secondAttribute="trailing" constant="20" id="5M3-vZ-vKG"/>
+                            <constraint firstItem="VGC-GZ-g7L" firstAttribute="width" secondItem="3Dc-fw-AHA" secondAttribute="width" id="8aU-tY-Mic"/>
+                            <constraint firstItem="TSw-JK-bjt" firstAttribute="centerY" secondItem="Phi-9Q-ATe" secondAttribute="centerY" id="Ing-af-c27"/>
+                            <constraint firstItem="VGC-GZ-g7L" firstAttribute="height" secondItem="3Dc-fw-AHA" secondAttribute="height" id="LKs-OO-wGp"/>
                             <constraint firstItem="j4s-M0-BpU" firstAttribute="centerY" secondItem="vDu-zF-Fre" secondAttribute="centerY" id="NhE-6X-5nj"/>
+                            <constraint firstItem="TSw-JK-bjt" firstAttribute="width" secondItem="Phi-9Q-ATe" secondAttribute="width" id="ULV-qT-n6B"/>
+                            <constraint firstItem="TSw-JK-bjt" firstAttribute="height" secondItem="Phi-9Q-ATe" secondAttribute="height" constant="1" id="WXF-VD-IPu"/>
+                            <constraint firstItem="VGC-GZ-g7L" firstAttribute="centerY" secondItem="3Dc-fw-AHA" secondAttribute="centerY" id="c28-7l-WjD"/>
+                            <constraint firstItem="TSw-JK-bjt" firstAttribute="centerX" secondItem="Phi-9Q-ATe" secondAttribute="centerX" id="gVk-Id-0Y9"/>
+                            <constraint firstItem="VGC-GZ-g7L" firstAttribute="centerX" secondItem="3Dc-fw-AHA" secondAttribute="centerX" id="ip6-3j-eVi"/>
                             <constraint firstItem="j4s-M0-BpU" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="rXR-2e-SuG"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="cancelButton" destination="TSw-JK-bjt" id="GU4-Ux-8xJ"/>
                         <outlet property="cancelLabel" destination="f6E-dr-Sp0" id="KDB-BU-Rdt"/>
+                        <outlet property="cancelView" destination="Phi-9Q-ATe" id="f5O-BR-EkB"/>
                         <outlet property="dialogueVIew" destination="j4s-M0-BpU" id="QDA-m8-kzd"/>
                         <outlet property="guideLabel" destination="XIe-ns-Hlq" id="QgI-sD-FZc"/>
+                        <outlet property="resetOrExitButton" destination="VGC-GZ-g7L" id="CUe-BD-UCK"/>
                         <outlet property="resetOrExitLabel" destination="w5g-YB-25v" id="FjM-3Y-pPn"/>
+                        <outlet property="resetOrExitView" destination="3Dc-fw-AHA" id="VYB-BV-Rgp"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--DialogueVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="DialogueVC" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" customClass="DialogueVC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="78" y="133"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        let rootViewController = UIStoryboard(name: Const.Storyboard.Name.sendSpark, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.sendSpark)
+        let rootViewController = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue)
         window?.rootViewController = rootViewController
         window?.makeKeyAndVisible()
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
@@ -28,12 +28,17 @@ class DialogueVC: UIViewController {
     @IBOutlet weak var cancelLabel: UILabel!
     @IBOutlet weak var resetOrExitLabel: UILabel!
     @IBOutlet weak var dialogueVIew: UIView!
+    @IBOutlet weak var cancelButton: UIButton!
+    @IBOutlet weak var resetOrExitButton: UIButton!
+    @IBOutlet weak var cancelView: UIView!
+    @IBOutlet weak var resetOrExitView: UIView!
     
     // MARK: Life Cycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
+        setAddtargets()
     }
     
 }
@@ -80,5 +85,46 @@ extension DialogueVC {
             print("dialogueType을 지정해주세요")
             
         }
+    }
+    
+    private func setAddtargets() {
+        cancelButton.addTarget(self, action: #selector(cancelAction), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(giveAlphaCancelViewColor), for: .touchDown)
+        cancelButton.addTarget(self, action: #selector(eraseAlphaCancelViewColor), for: .touchDragOutside)
+        resetOrExitButton.addTarget(self, action: #selector(resetOrExitAction), for: .touchUpInside)
+        resetOrExitButton.addTarget(self, action: #selector(giveAlphaResetOrExitViewColor), for: .touchDown)
+        resetOrExitButton.addTarget(self, action: #selector(eraseAlphaResetOrExitViewColor), for: .touchDragOutside)
+    }
+    
+    // MARK: objc methods
+    
+    @objc
+    private func cancelAction() {
+        self.dismiss(animated: false, completion: nil)
+    }
+    
+    @objc
+    private func resetOrExitAction() {
+        // 나가기 또는 초기화 액션을 넣어주세요
+    }
+    
+    @objc
+    private func giveAlphaCancelViewColor() {
+        cancelView.alpha = 0.5
+    }
+    
+    @objc
+    private func eraseAlphaCancelViewColor() {
+        cancelView.alpha = 1
+    }
+    
+    @objc
+    private func giveAlphaResetOrExitViewColor() {
+        resetOrExitView.alpha = 0.5
+    }
+    
+    @objc
+    private func eraseAlphaResetOrExitViewColor() {
+        resetOrExitView.alpha = 1
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
@@ -7,10 +7,78 @@
 
 import UIKit
 
+import SnapKit
+
+@frozen enum DialogueType {
+    case exitSignUp
+    case exitAuth
+    case resetTimer
+    case exitTimer
+}
+
 class DialogueVC: UIViewController {
 
+    // MARK: Properties
+    
+    var dialogueType: DialogueType?
+    
+    // MARK: IBoutlet Properties
+    
+    @IBOutlet weak var guideLabel: UILabel!
+    @IBOutlet weak var cancelLabel: UILabel!
+    @IBOutlet weak var resetOrExitLabel: UILabel!
+    @IBOutlet weak var dialogueVIew: UIView!
+    
+    // MARK: Life Cycles
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        setUI()
+    }
+    
+}
 
+// MARK: Methods
+extension DialogueVC {
+    private func setUI() {
+        view.backgroundColor = .sparkBlack.withAlphaComponent(0.8)
+        
+        dialogueVIew.layer.cornerRadius = 2
+        
+        dialogueType = .exitTimer
+        
+        guideLabel.font = .p1TitleLight
+        cancelLabel.font = .btn3
+        resetOrExitLabel.font = .btn3
+        resetOrExitLabel.textColor = .sparkDarkPinkred
+        
+        switch dialogueType {
+            
+        case .exitSignUp:
+            guideLabel.text = """
+            회원가입이 완료되지 않았습니다.
+            그래도 나가시겠습니까?
+            """
+            
+        case .exitAuth:
+            guideLabel.text = """
+            인증이 완료되지 않았습니다.
+            그래도 나가시겠습니까?
+            """
+            
+        case .resetTimer:
+            guideLabel.text = "스톱워치를 초기화하시겠습니까?"
+            resetOrExitLabel.text = "초기화"
+            
+        case .exitTimer:
+            guideLabel.text = """
+            이미 측정한 시간 기록이 사라집니다.
+            그래도 나가시겠습니까?
+            """
+            
+        case .none:
+            print("dialogueType을 지정해주세요")
+            
+        }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
@@ -27,7 +27,7 @@ class DialogueVC: UIViewController {
     @IBOutlet weak var guideLabel: UILabel!
     @IBOutlet weak var cancelLabel: UILabel!
     @IBOutlet weak var resetOrExitLabel: UILabel!
-    @IBOutlet weak var dialogueVIew: UIView!
+    @IBOutlet weak var dialogueView: UIView!
     @IBOutlet weak var cancelButton: UIButton!
     @IBOutlet weak var resetOrExitButton: UIButton!
     @IBOutlet weak var cancelView: UIView!
@@ -38,7 +38,7 @@ class DialogueVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
-        setAddtargets()
+        setAddTargets()
     }
     
 }
@@ -48,7 +48,7 @@ extension DialogueVC {
     private func setUI() {
         view.backgroundColor = .sparkBlack.withAlphaComponent(0.8)
         
-        dialogueVIew.layer.cornerRadius = 2
+        dialogueView.layer.cornerRadius = 2
         
         dialogueType = .exitTimer
         
@@ -87,7 +87,7 @@ extension DialogueVC {
         }
     }
     
-    private func setAddtargets() {
+    private func setAddTargets() {
         cancelButton.addTarget(self, action: #selector(cancelAction), for: .touchUpInside)
         cancelButton.addTarget(self, action: #selector(giveAlphaCancelViewColor), for: .touchDown)
         cancelButton.addTarget(self, action: #selector(eraseAlphaCancelViewColor), for: .touchDragOutside)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
@@ -1,0 +1,16 @@
+//
+//  DialogueVC.swift
+//  Spark-iOS
+//
+//  Created by Junho Lee on 2022/01/18.
+//
+
+import UIKit
+
+class DialogueVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+}


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#113

🌱 작업한 내용
- 총 4개의 케이스에 대한 다이얼로그 구현
- 회원가입 나가기
- 인증 나가기
- 타이머 초기화
- 타이머 나가기

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- dialogue를 호출할 때 dialogueType 프로퍼티를 지정해주시면 됩니다.
- resetOrExitAction에 원하는 액션을 넣어주시면 됩니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|디자인|![Simulator Screen Recording - iPhone 11 Pro - 2022-01-19 at 04 12 48](https://user-images.githubusercontent.com/77208067/150003229-6e7be1fb-deee-4448-8188-83c9bb907c8e.gif)|



## 📮 관련 이슈
- Resolved: #113 
