### PR TITLE
[Fix] #140 - 탭바에서 네비게이션 바 QA

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Extensions/UINavigationController+.swift
+++ b/Spark-iOS/Spark-iOS/Source/Extensions/UINavigationController+.swift
@@ -68,6 +68,7 @@ extension UINavigationController {
         self.navigationBar.standardAppearance = appearance
         self.navigationBar.scrollEdgeAppearance = appearance
         self.navigationBar.tintColor = tintColor
+        navigationItem?.title = ""
         
         let firstButton = UIBarButtonItem(image: UIImage(named: "icProfile"), style: .plain, target: self.topViewController, action: firstButtonSelector)
         let secondButton = UIBarButtonItem(image: UIImage(named: "icNotice"), style: .plain, target: self.topViewController, action: secondButtonSelector)

--- a/Spark-iOS/Spark-iOS/Source/Extensions/UINavigationController+.swift
+++ b/Spark-iOS/Spark-iOS/Source/Extensions/UINavigationController+.swift
@@ -94,8 +94,8 @@ extension UINavigationController {
         let rightButton = UIBarButtonItem(image: rightButtonImage, style: .plain, target: self.topViewController, action: rightButtonSelector)
         navigationItem?.leftBarButtonItem = reftButton
         navigationItem?.rightBarButtonItem = rightButton
-        
-        self.navigationBar.topItem?.title = title
+
+        navigationItem?.title = title
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
@@ -102,9 +102,12 @@ extension SplashVC {
     }
     
     private func presentToMain() {
-        guard let mainVC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
+        guard let rootVC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
+        
+        let mainVC = UINavigationController(rootViewController: rootVC)
         mainVC.modalPresentationStyle = .fullScreen
         mainVC.modalTransitionStyle = .crossDissolve
+        
         self.present(mainVC, animated: true, completion: nil)
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -68,7 +68,6 @@ extension StorageMoreVC {
     
     private func setUI() {
         view.backgroundColor = .sparkBlack
-        tabBarController?.tabBar.isHidden = true
         navigationController?.isNavigationBarHidden = false
         navigationController?.initWithBackButtonTitle(title: titleText ?? "", tintColor: .sparkWhite, backgroundColor: .sparkBlack)
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -47,6 +47,7 @@ class FeedVC: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = true
         
         NotificationCenter.default.post(name: .disappearFloatingButton, object: nil)
         

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -37,6 +37,8 @@ class HomeVC: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        navigationController?.isNavigationBarHidden = false
+        
         NotificationCenter.default.post(name: .appearFloatingButton, object: nil)
         
         self.habitRoomLastID = -1
@@ -60,13 +62,6 @@ class HomeVC: UIViewController {
 
 extension HomeVC {
     private func setUI() {
-        // set navigationController
-        navigationController?.initWithRightTwoCustomButtons(navigationItem: self.navigationItem,
-                                                            tintColor: .sparkBlack,
-                                                            backgroundColor: .sparkWhite,
-                                                            firstButtonSelector: #selector(presentToProfileVC),
-                                                            secondButtonSelector: #selector(presentToAertVC))
-        
         // set collectionView
         mainCollectionView.backgroundColor = .clear
         let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
@@ -23,6 +23,18 @@ class MainTBC: UITabBarController {
         setAddTarget()
         setFloatingButton()
         setNotification()
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        navigationController?.isNavigationBarHidden = false
+        navigationController?.initWithRightTwoCustomButtons(navigationItem: self.navigationItem,
+                                                            tintColor: .sparkBlack,
+                                                            backgroundColor: .sparkWhite,
+                                                            firstButtonSelector: #selector(presentToProfileVC),
+                                                            secondButtonSelector: #selector(presentToAertVC))
     }
 }
 
@@ -40,10 +52,11 @@ extension MainTBC {
     
         UITabBarItem.appearance().setTitleTextAttributes([NSAttributedString.Key.font: UIFont.caption], for: .normal)
         
-        let homeNVC = UINavigationController(rootViewController: homeVC)
-        let storageNVC = UINavigationController(rootViewController: storageVC)
+        // FIXME: - 준호 보관함 테스트해보고 쓰지 않는다면 지우자
+//        let homeNVC = UINavigationController(rootViewController: homeVC)
+//        let storageNVC = UINavigationController(rootViewController: storageVC)
         
-        setViewControllers([feedVC, homeNVC, storageNVC], animated: false)
+        setViewControllers([feedVC, homeVC, storageVC], animated: false)
         
         tabBar.tintColor = .sparkDarkPinkred
         tabBar.itemPositioning = .centered
@@ -61,7 +74,7 @@ extension MainTBC {
 
         if #available(iOS 15.0, *) {
                 // set tabbar opacity
-                tabBar.scrollEdgeAppearance = tabBar.standardAppearance
+            tabBar.scrollEdgeAppearance = tabBar.standardAppearance
         }
     }
     
@@ -147,5 +160,17 @@ extension MainTBC {
             floatingButton.buttonColor = .sparkDarkPinkred
             floatingButton.buttonImageColor = .sparkWhite
         }
+    }
+    
+    // TODO: - 화면전환
+    
+    @objc
+    private func presentToProfileVC() {
+        
+    }
+    
+    @objc
+    private func presentToAertVC() {
+        
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
@@ -113,8 +113,7 @@ class StorageVC: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.navigationController?.isNavigationBarHidden = true
-        tabBarController?.tabBar.isHidden = false
+        navigationController?.isNavigationBarHidden = true
         NotificationCenter.default.post(name: .disappearFloatingButton, object: nil)
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -65,7 +65,6 @@ class WaitingVC: UIViewController {
         super.viewWillAppear(animated)
 
         getWaitingRoomWithAPI(roomID: roomId ?? 0)
-//        getWaitingRoomWithAPI(roomID: 235)
     }
 
     // MARK: - Methods


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#140

🌱 작업한 내용
- 탭바를 네비게이션 컨트롤러에 얹어서 스플래시에서 화면전환
- 피드에서는 네비바 안보임
- 홈에서는 네비바 보임. 타이틀없음
- 보관함에서는 네비바 안보임.
- 보관함 인증사진 모아보기에서는 네비바 보임.

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📮 관련 이슈
- Resolved: #140
