### PR TITLE
[Fix] #159 - 피드뷰 레이아웃 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Feed.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Feed.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
@@ -137,6 +137,7 @@ extension FeedCVC {
         profileImageView.layer.masksToBounds = true
         profileImageView.contentMode = .scaleAspectFill
         feedImageView.contentMode = .scaleAspectFill
+        feedImageView.layer.masksToBounds = true
         
         sparkLabel.text = "받은 스파크"
         
@@ -193,7 +194,7 @@ extension FeedCVC {
         
         feedImageView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
-            make.height.equalTo(feedImageView.snp.width).multipliedBy(1.0 / 1.0)
+            make.height.equalTo(self.snp.width).multipliedBy(1.0 / 1.0)
         }
         
         fadeImageView.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -48,6 +48,7 @@ class AuthTimerVC: UIViewController {
         super.viewWillAppear(animated)
         
         navigationController?.isNavigationBarHidden = true
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
     }
     
     // MARK: - Methods

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -25,28 +25,22 @@ class CreateRoomVC: UIViewController {
 
     // MARK: - View Life Cycles
     
-    override func viewWillAppear(_ animated: Bool) {
-        navigationController?.isNavigationBarHidden = true
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-
         setUI()
         setLayout()
         setNotification()
         setAddTarget()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.isNavigationBarHidden = true
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
+    }
+    
     // MARK: - Methods
     
     private func setUI() {
-//        navigationController?.initWithLeftButtonTitle(title: "aa",
-//                                                      tintColor: .sparkBlack,
-//                                                      backgroundColor: .white,
-//                                                      image: UIImage(named: "icQuit"),
-//                                                      selector: #selector(touchCloseButton))
-        
         closeButton.setImage(UIImage(named: "icQuit"), for: .normal)
         
         titleLabel.text = "어떤 습관방을 만들건가요?"
@@ -213,5 +207,4 @@ extension CreateRoomVC: UITextFieldDelegate {
             disableButton()
         }
     }
-    
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/CompleteAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/CompleteAuthVC.swift
@@ -42,8 +42,10 @@ class CompleteAuthVC: UIViewController {
     // MARK: IBActions
     @IBAction func goToFeedVC(_ sender: Any) {
         guard let presentingVC = self.presentingViewController?.presentingViewController as? UITabBarController else { return }
+        guard let naviVC = presentingVC.viewControllers?[1] as? UINavigationController else { return }
         
-        self.presentingViewController?.presentingViewController?.dismiss(animated: false) {
+        presentingVC.dismiss(animated: false) {
+            naviVC.popViewController(animated: false)
             presentingVC.selectedIndex = 0
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -96,6 +96,7 @@ class HabitRoomVC: UIViewController {
 extension HabitRoomVC {
     private func setUI() {
         navigationController?.isNavigationBarHidden = true
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
     
         tabBarController?.tabBar.isHidden = true
         NotificationCenter.default.post(name: .disappearFloatingButton, object: nil)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -51,7 +51,6 @@ class FeedVC: UIViewController {
         NotificationCenter.default.post(name: .disappearFloatingButton, object: nil)
         tabBarController?.tabBar.isHidden = false
         // FIXME: - getFeedListFetchWithAPI를 여기서 호출하는거로 변경
-//        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
         DispatchQueue.main.async {
             self.getFeedListFetchWithAPI(lastID: self.feedLastID) {
                 self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -38,11 +38,11 @@ class FeedVC: UIViewController {
         setCollectionView()
         
         // FIXME: - getFeedListFetchWithAPI 위치 변경
-//        DispatchQueue.main.async {
-//            self.getFeedListFetchWithAPI(lastID: self.feedLastID) {
-////                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
-//            }
-//        }
+        DispatchQueue.main.async {
+            self.getFeedListFetchWithAPI(lastID: self.feedLastID) {
+//                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
+            }
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -51,11 +51,11 @@ class FeedVC: UIViewController {
         NotificationCenter.default.post(name: .disappearFloatingButton, object: nil)
         tabBarController?.tabBar.isHidden = false
         // FIXME: - getFeedListFetchWithAPI를 여기서 호출하는거로 변경
-        DispatchQueue.main.async {
-            self.getFeedListFetchWithAPI(lastID: self.feedLastID) {
-                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
-            }
-        }
+//        DispatchQueue.main.async {
+//            self.getFeedListFetchWithAPI(lastID: self.feedLastID) {
+//                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
+//            }
+//        }
     }
     
     // MARK: - Methods

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -38,11 +38,11 @@ class FeedVC: UIViewController {
         setCollectionView()
         
         // FIXME: - getFeedListFetchWithAPI 위치 변경
-        DispatchQueue.main.async {
-            self.getFeedListFetchWithAPI(lastID: self.feedLastID) {
-//                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
-            }
-        }
+//        DispatchQueue.main.async {
+//            self.getFeedListFetchWithAPI(lastID: self.feedLastID) {
+////                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
+//            }
+//        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -52,6 +52,11 @@ class FeedVC: UIViewController {
         tabBarController?.tabBar.isHidden = false
         // FIXME: - getFeedListFetchWithAPI를 여기서 호출하는거로 변경
 //        collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
+        DispatchQueue.main.async {
+            self.getFeedListFetchWithAPI(lastID: self.feedLastID) {
+                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
+            }
+        }
     }
     
     // MARK: - Methods


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#159

🌱 작업한 내용
- feedImageView 이미지 레이아웃이 엉망인 상태 해결
- 인증하고 피드로 왔을 때 홈 탭했을 때 상세뷰 떠있는 문제 해결
- swipe back gesture 추가

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
스와이프에게 자유를.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|생략|생략|

## 📮 관련 이슈
- Resolved: #159 
