### PR TITLE
[Fix] #216 - 대기방에서 뷰 dismiss 분기처리

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
@@ -104,7 +104,7 @@ extension JoinCheckVC {
                 
                 guard let rootViewController = nextSB.instantiateViewController(identifier: Const.ViewController.Identifier.waiting) as? WaitingVC else {return}
                 rootViewController.roomId = roomID
-                rootViewController.isFromHome = false
+                rootViewController.fromWhereStatus = .joinCode
                 rootViewController.roomName = self.roomName
                 
                 let nextVC = UINavigationController(rootViewController: rootViewController)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -93,6 +93,7 @@ class CreateAuthVC: UIViewController {
             guard let rootVC = UIStoryboard(name: Const.Storyboard.Name.waiting, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.waiting) as? WaitingVC else { return }
             rootVC.roomName = self.roomName
             rootVC.roomId = self.roomId
+            rootVC.fromWhereStatus = .makeRoom
             
             let nextVC = UINavigationController(rootViewController: rootVC)
             nextVC.modalTransitionStyle = .crossDissolve

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -157,7 +157,7 @@ extension HomeVC: UICollectionViewDelegate {
                 // 대기방
                 guard let waitingVC = UIStoryboard(name: Const.Storyboard.Name.waiting, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.waiting) as? WaitingVC else { return }
                 waitingVC.roomId = habitRoomList[indexPath.item].roomID
-                waitingVC.isFromHome = true
+                waitingVC.fromWhereStatus = .fromHome
                 waitingVC.roomName = habitRoomList[indexPath.item].roomName
                 
                 navigationController?.pushViewController(waitingVC, animated: true)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -316,10 +316,6 @@ class WaitingVC: UIViewController {
     
     @objc
     func dismissJoinCodeToHomeVC() {
-        print("presentingVC: ", presentingViewController)
-        print("presentingVC.presentingVC: ", presentingViewController?.presentingViewController)
-        print("presentingVC.presentingVC.presentingVC: ", presentingViewController?.presentingViewController?.presentingViewController)
-        
         presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true)
         NotificationCenter.default.post(name: .appearFloatingButton, object: nil)
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -311,13 +311,11 @@ class WaitingVC: UIViewController {
     @objc
     func dismissToHomeVC() {
         presentingViewController?.presentingViewController?.dismiss(animated: true)
-        NotificationCenter.default.post(name: .appearFloatingButton, object: nil)
     }
     
     @objc
     func dismissJoinCodeToHomeVC() {
         presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true)
-        NotificationCenter.default.post(name: .appearFloatingButton, object: nil)
     }
     
     @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -8,47 +8,46 @@
 import UIKit
 
 import SnapKit
-import SwiftUI
 import Lottie
 
 class WaitingVC: UIViewController {
     
     // MARK: - Properties
     
-    let copyButton = UIButton()
-    let checkTitleLabel = UILabel()
-    let toolTipButton = UIButton()
-    let toolTipImageView = UIImageView()
-    let stopwatchLabel = UILabel()
-    let checkDivideView = UIView()
-    let photoLabel = UILabel()
-    let firstDivideView = UIView()
+    private let copyButton = UIButton()
+    private let checkTitleLabel = UILabel()
+    private let toolTipButton = UIButton()
+    private let toolTipImageView = UIImageView()
+    private let stopwatchLabel = UILabel()
+    private let checkDivideView = UIView()
+    private let photoLabel = UILabel()
+    private let firstDivideView = UIView()
     
-    let goalTitleLabel = UILabel()
-    let profileImageView = UIImageView()
-    let nicknameLabel = UILabel()
-    let timeLabel = UILabel()
-    let goalLabel = UILabel()
-    let editButton = UIButton()
-    let secondDivideView = UIView()
+    private let goalTitleLabel = UILabel()
+    private let profileImageView = UIImageView()
+    private let nicknameLabel = UILabel()
+    private let timeLabel = UILabel()
+    private let goalLabel = UILabel()
+    private let editButton = UIButton()
+    private let secondDivideView = UIView()
     
-    let friendTitleLabel = UILabel()
-    let friendCountLabel = UILabel()
-    let friendSubTitleLabel = UILabel()
-    let refreshButton = UIButton()
-    let startButton = UIButton()
+    private let friendTitleLabel = UILabel()
+    private let friendCountLabel = UILabel()
+    private let friendSubTitleLabel = UILabel()
+    private let refreshButton = UIButton()
+    private let startButton = UIButton()
     
     private let tapGestrueRecognizer = UITapGestureRecognizer()
+    private let collectionViewFlowLayout = UICollectionViewFlowLayout()
     
-    let collectionViewFlowLayout = UICollectionViewFlowLayout()
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
-    
     lazy var loadingBgView = UIView()
     lazy var loadingView = AnimationView(name: Const.Lottie.Name.loading)
     
-    var members: [Member] = []
-    var memberList: [Any] = []
-    var photoOnly: Bool? /// 사진 인증만
+    private var members: [Member] = []
+    private var memberList: [Any] = []
+    
+    var photoOnly: Bool? // 사진 인증만
     var roomName: String?
     var roomCode: String?
     var roomId: Int?

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -339,10 +339,11 @@ class WaitingVC: UIViewController {
             self.postStartRoomWithAPI(roomID: self.roomId ?? 0) {
                 switch self.fromWhereStatus {
                 case .fromHome:
-                    self.navigationController?.popViewController(animated: true)
+                    self.popToHomeVC()
                 case .makeRoom:
-                    self.presentingViewController?.presentingViewController?.dismiss(animated: true)
+                    self.dismissToHomeVC()
                 case .joinCode:
+                    // 코드로 참여시에는 createButton 이 히든되어 있어서 아무런 동작이 필요하지 않다.
                     return
                 case .none:
                     print("fromeWhereStatus 를 지정해주세요.")


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#216

🌱 작업한 내용
- 대기방에서 dismiss 하는 분기처리
- FromWhereStatus 를 통해서 열거형으로 분기처리

```swift
/// 대기방을 접근하는 플로우를 알려주는 상태.
/// - fromHome : 홈에서 대기방 올 때.
/// - joinCode : 코드로 참여할 때.
/// - makeRoom : 방만들기로 대기방 올 때.

@frozen
enum FromWhereStatus {
    case fromHome
    case joinCode
    case makeRoom
}
```

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 코드로 참여할 때 presenting view controller 를 로그로 찍어봤다.

<img width="600" alt="스크린샷 2022-01-27 오후 7 01 40" src="https://user-images.githubusercontent.com/69136340/151336594-c50a9605-64cc-4d0f-9a6d-74ec661fe94d.png">

> 지금은 스플래쉬 | 홈 | 코드입력팝업 | 코드참여 확인뷰 | 대기방

> 구조이고, 우리는 `presentingViewController?.presentingViewController` 이렇게 사용해서 `코드참여 확인뷰`를 닫고, `코드입력팝업`을 닫으려고 했어요! 하지만 그렇지를 못했져 이유를 알아봅시다..  

화면을 `dismiss` 로 걷어내는 객체는 해당 뷰컨이 아니라구 해여!  VC1이 VC2를 불렀다고 가정한다면, VC2가 화면에서 걷어지기 위해서는 VC1가 걷어줘야하는거죠!
어라..? 그러면  `self.dismiss` 가 아니라 `self.presentingViewController.dismiss` 를 써야하는거 아닌가요?
에 대한 답변으로 사용자의 관점에서 전혀 차이를 느낄 수 없다고 해여 

```swift
이 두 함수의 차이는 completion 함수 구현 시 발생한다.
dissmiss를 한 이후에 결과를 presentingViewController에게 알려주느냐 아니면 사라진 ViewController(self)에게 알려주느냐의 차이가 있다.
```

그래서 코드 입력하는 팝업창을 부르는 `presentingViewController?. presentingViewController?. presentingViewController?` 에서 `dismiss` 를 해주어야했던 것이지요.

> 참고: https://velog.io/@ellyheetov/화면전환

개발자 문서를 찾아볼게여~

# dismiss(animated:completion:)

Dismisses the view controller that was presented modally by the view controller.

### Parameters

- **falg**

transition 에 애니메이션을 적용하려면 true 를 전달해야한다.

- **completion**

뷰 컨트롤러가 dismiss 된 후 실행할 블록이다.

### Discussion

`presenting view controller` 는 자신이 present 한 뷰컨트롤러를 닫을 책임이 있습니다. `presented view controller` 자체에서 이 메서드를 호출하면 UIKit 는 `presenting view controller` 에게 해제를 처리하도록 요청합니다.

여러 뷰컨트롤러를 연속적으로 present 해서 `presented view controller` 스택을 구축하는 경우, 스택의 낮은 뷰컨트롤러에서 이 메서드를 호출하면 바로 자식 뷰컨트롤러와 위의 모든 뷰컨트롤러가 해제됩니다.

이런일이 발생하면, 맨위의 뷰만 애니메이션 방식으로 닫힙니다. 중간 뷰컨트롤러는 스택에서 간단히 제거됩니다. 맨위의 뷰는 modal transition stlye 을 사용하여 dismiss 됩니다. 이 스타일은 스택의 다른 하위 뷰컨트롤러에서 사용하는 것과 다를 수 있다.

만약 `presented view controller` 에 대한 참조를 유지하려면 이 메서드를 호출하기 전에 `presentedViewController` 속성의 값을 가져와야 합니다.

`completion` 핸들러는 `presented view controller` 에서 `viewDidDisappear(_:)` 메서드 호출된 다음에 호출됩니다.


> 참고: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621505-dismiss
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능|<img src="https://user-images.githubusercontent.com/69136340/151336069-f929265e-7eea-4404-83cc-eddb23226240.MP4" width ="250">|

## 📮 관련 이
- Resolved: #216
