### PR TITLE
[Feat] #210 - 피드 좋아요 로티 문제 해결

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Constants/Cell.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Cell.swift
@@ -20,6 +20,7 @@ extension Const {
             static let homeEmptyCVC = "HomeEmptyCVC"
             static let habitRoomMemeberCVC = "HabitRoomMemberCVC"
             static let waitingFriendCVC = "WaitingFriendCVC"
+            static let feedCVC = "FeedCVC"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
@@ -45,6 +45,7 @@ class FeedCVC: UICollectionViewCell {
         setUI()
         setStackView()
         setLayout()
+//        setLikeLottie()
         setAddTarget()
     }
     
@@ -63,7 +64,7 @@ class FeedCVC: UICollectionViewCell {
         feedImageView.image = UIImage()
         fadeImageView.image = UIImage()
         profileImageView.image = UIImage()
-        likeState = true
+        likeState = false
     }
     
     // MARK: - Methods
@@ -110,7 +111,7 @@ class FeedCVC: UICollectionViewCell {
         let originLike = Int(likeCountLabel.text ?? "") ?? 0
         if !likeState {
             // like 눌리지 않음 -> 눌림
-            setLikeLottie()
+            playLikeLottie()
             
             likeButton.setImage(UIImage(named: "icHeartActive"), for: .normal)
             likeCountLabel.textColor = .sparkDarkPinkred
@@ -164,6 +165,12 @@ extension FeedCVC {
         doneImageView.image = UIImage(named: "tagDone")
         sparkIconImageView.image = UIImage(named: "icFire")
         likeButton.setImage(UIImage(named: "icHeartInactive"), for: .normal)
+        
+        lottieView.center = likeButton.center
+        lottieView.loopMode = .playOnce
+        lottieView.contentMode = .scaleAspectFit
+        lottieView.layer.masksToBounds = true
+        lottieView.isHidden = true
     }
     
     private func setStackView() {
@@ -183,22 +190,28 @@ extension FeedCVC {
         sparkStackView.addArrangedSubview(sparkCountLabel)
     }
     
-    private func setLikeLottie() {
-        self.addSubview(lottieView)
-
-        lottieView.snp.makeConstraints { make in
-            make.center.equalTo(likeButton.snp.center)
-            make.width.height.equalTo(40)
-        }
-
-        lottieView.center = likeButton.center
-        lottieView.loopMode = .playOnce
-        lottieView.contentMode = .scaleAspectFit
-        lottieView.layer.masksToBounds = true
-        lottieView.play {_ in
-            print("되는거여?🤬")
+//    private func setLikeLottie() {
+//        self.addSubview(lottieView)
+//
+//        lottieView.snp.makeConstraints { make in
+//            make.center.equalTo(likeButton.snp.center)
+//            make.width.height.equalTo(40)
+//        }
+//
+//        lottieView.center = likeButton.center
+//        lottieView.loopMode = .playOnce
+//        lottieView.contentMode = .scaleAspectFit
+//        lottieView.layer.masksToBounds = true
+//        lottieView.isHidden = true
+//        self.bringSubviewToFront(likeButton)
+//    }
+    
+    private func playLikeLottie() {
+        lottieView.isHidden = false
+        
+        lottieView.play { _ in
             self.lottieView.stop()
-            self.lottieView.removeFromSuperview()
+            self.lottieView.isHidden = true
         }
     }
 }
@@ -208,7 +221,7 @@ extension FeedCVC {
     private func setLayout() {
         self.addSubviews([feedImageView, fadeImageView, profileImageView,
                           nameLabel, titleStackView, timeLabel,
-                          sparkStackView, likeButton, likeCountLabel])
+                          sparkStackView, lottieView, likeButton, likeCountLabel])
         
         feedImageView.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
@@ -252,6 +265,11 @@ extension FeedCVC {
         likeButton.snp.makeConstraints { make in
             make.top.equalTo(feedImageView.snp.bottom).offset(20)
             make.trailing.equalToSuperview().inset(50)
+        }
+        
+        lottieView.snp.makeConstraints { make in
+            make.center.equalTo(likeButton.snp.center)
+            make.width.height.equalTo(40)
         }
         
         likeCountLabel.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
@@ -53,7 +53,9 @@ class FeedCVC: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // FIXME: - 두개의 셀이 보일 때, 아래의 셀에서 하트를 누르면 위 셀의 하트 로티가 작동.. 로티는 어떻게 초기화 시켜주지...
     override func prepareForReuse() {
+        super.prepareForReuse()
         titleLabel.text = ""
         nameLabel.text = ""
         sparkCountLabel.text = ""
@@ -62,7 +64,7 @@ class FeedCVC: UICollectionViewCell {
         feedImageView.image = UIImage()
         fadeImageView.image = UIImage()
         profileImageView.image = UIImage()
-        likeState = false
+        likeState = true
     }
     
     // MARK: - Methods
@@ -109,10 +111,7 @@ class FeedCVC: UICollectionViewCell {
         let originLike = Int(likeCountLabel.text ?? "") ?? 0
         if !likeState {
             // like 눌리지 않음 -> 눌림
-            setLikeLottie {
-                self.lottieView.stop()
-                self.lottieView.removeFromSuperview()
-            }
+            setLikeLottie()
             
             likeButton.setImage(UIImage(named: "icHeartActive"), for: .normal)
             likeCountLabel.textColor = .sparkDarkPinkred
@@ -185,7 +184,7 @@ extension FeedCVC {
         sparkStackView.addArrangedSubview(sparkCountLabel)
     }
     
-    private func setLikeLottie(completion: @escaping () -> Void) {
+    private func setLikeLottie() {
         self.addSubview(lottieView)
 
         lottieView.snp.makeConstraints { make in
@@ -193,14 +192,14 @@ extension FeedCVC {
             make.width.height.equalTo(40)
         }
 
-        lottieView.backgroundColor = .clear
         lottieView.center = likeButton.center
         lottieView.loopMode = .playOnce
         lottieView.contentMode = .scaleAspectFit
         lottieView.layer.masksToBounds = true
         lottieView.play {_ in
-            print("play 했는데 왜 안돼? ⚡️")
-            completion()
+            print("되는거여?🤬")
+            self.lottieView.stop()
+            self.lottieView.removeFromSuperview()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
@@ -11,7 +11,6 @@ import SnapKit
 import Lottie
 
 class FeedCVC: UICollectionViewCell {
-    static let identifier = "FeedCVC"
     
     // MARK: - Properties
     

--- a/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
@@ -170,7 +170,7 @@ extension FeedCVC {
     
     private func setStackView() {
         titleStackView.axis = .horizontal
-        titleStackView.alignment = .fill
+        titleStackView.alignment = .bottom
         titleStackView.distribution = .equalSpacing
         titleStackView.spacing = 8
         titleStackView.addArrangedSubview(titleLabel)
@@ -239,6 +239,7 @@ extension FeedCVC {
         titleStackView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.top.equalTo(nameLabel.snp.bottom).offset(8)
+            make.height.equalTo(26)
         }
         
         sparkStackView.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
@@ -45,7 +45,6 @@ class FeedCVC: UICollectionViewCell {
         setUI()
         setStackView()
         setLayout()
-//        setLikeLottie()
         setAddTarget()
     }
     
@@ -53,7 +52,6 @@ class FeedCVC: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // FIXME: - 두개의 셀이 보일 때, 아래의 셀에서 하트를 누르면 위 셀의 하트 로티가 작동.. 로티는 어떻게 초기화 시켜주지...
     override func prepareForReuse() {
         super.prepareForReuse()
         titleLabel.text = ""
@@ -105,7 +103,6 @@ class FeedCVC: UICollectionViewCell {
         likeButton.addTarget(self, action: #selector(tapLikeButton), for: .touchUpInside)
     }
     
-    // FIXME: - 고쳐
     @objc
     func tapLikeButton() {
         let originLike = Int(likeCountLabel.text ?? "") ?? 0
@@ -189,22 +186,6 @@ extension FeedCVC {
         sparkStackView.addArrangedSubview(sparkIconImageView)
         sparkStackView.addArrangedSubview(sparkCountLabel)
     }
-    
-//    private func setLikeLottie() {
-//        self.addSubview(lottieView)
-//
-//        lottieView.snp.makeConstraints { make in
-//            make.center.equalTo(likeButton.snp.center)
-//            make.width.height.equalTo(40)
-//        }
-//
-//        lottieView.center = likeButton.center
-//        lottieView.loopMode = .playOnce
-//        lottieView.contentMode = .scaleAspectFit
-//        lottieView.layer.masksToBounds = true
-//        lottieView.isHidden = true
-//        self.bringSubviewToFront(likeButton)
-//    }
     
     private func playLikeLottie() {
         lottieView.isHidden = false

--- a/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedCVC.swift
@@ -15,29 +15,29 @@ class FeedCVC: UICollectionViewCell {
     
     // MARK: - Properties
     
-    let feedImageView = UIImageView()
-    let fadeImageView = UIImageView()
-    let timeLabel = UILabel()
-    let profileImageView = UIImageView()
-    let nameLabel = UILabel()
+    private let feedImageView = UIImageView()
+    private let fadeImageView = UIImageView()
+    private let timeLabel = UILabel()
+    private let profileImageView = UIImageView()
+    private let nameLabel = UILabel()
     
-    let titleStackView = UIStackView()
-    let titleLabel = UILabel()
-    let doneImageView = UIImageView()
+    private let titleStackView = UIStackView()
+    private let titleLabel = UILabel()
+    private let doneImageView = UIImageView()
     
-    let sparkStackView = UIStackView()
-    let sparkLabel = UILabel()
-    let sparkIconImageView = UIImageView()
-    let sparkCountLabel = UILabel()
+    private let sparkStackView = UIStackView()
+    private let sparkLabel = UILabel()
+    private let sparkIconImageView = UIImageView()
+    private let sparkCountLabel = UILabel()
     
-    let likeButton = UIButton()
-    let likeCountLabel = UILabel()
-    let lottieView = AnimationView(name: "icHeartActive")
+    private let likeButton = UIButton()
+    private let likeCountLabel = UILabel()
+    private let lottieView = AnimationView(name: "icHeartActive")
     
     weak var likeDelegate: FeedCellDelegate?
-    var likeState: Bool = false
-    var cellId: Int = 0
-    var indexPath: IndexPath?
+    private var likeState: Bool = false
+    private var cellId: Int = 0
+    private var indexPath: IndexPath?
     
     // MARK: - View Life Cycles
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -339,7 +339,6 @@ extension FeedVC: UICollectionViewDelegateFlowLayout {
 // MARK: - Protocol
 extension FeedVC: FeedCellDelegate {
     func likeButtonTapped(recordID: Int, indexPath: IndexPath, likeState: Bool) {
-        // FIXME: - 고쳐
         if indexPath.section == 0 {
             if likeState {
                 firstList[indexPath.item].isLiked = false
@@ -398,7 +397,6 @@ extension FeedVC: FeedCellDelegate {
             }
         }
          
-//        collectionView.reloadData()
         postFeedLikeWithAPI(recordID: recordID)
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -100,7 +100,7 @@ class FeedVC: UIViewController {
         collectionView.dataSource = self
         
         collectionView.register(FeedHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FeedHeaderView.identifier)
-        collectionView.register(FeedCVC.self, forCellWithReuseIdentifier: FeedCVC.identifier)
+        collectionView.register(FeedCVC.self, forCellWithReuseIdentifier: Const.Cell.Identifier.feedCVC)
         collectionView.register(FeedEmptyCVC.self, forCellWithReuseIdentifier: FeedEmptyCVC.identifier)
         
         collectionViewFlowlayout.scrollDirection = .vertical
@@ -259,7 +259,7 @@ extension FeedVC: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if dateList.count != 0 {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FeedCVC.identifier, for: indexPath) as? FeedCVC else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.feedCVC, for: indexPath) as? FeedCVC else { return UICollectionViewCell() }
             
             var alist: Record
             

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -339,6 +339,7 @@ extension FeedVC: UICollectionViewDelegateFlowLayout {
 // MARK: - Protocol
 extension FeedVC: FeedCellDelegate {
     func likeButtonTapped(recordID: Int, indexPath: IndexPath, likeState: Bool) {
+        // FIXME: - 고쳐
         if indexPath.section == 0 {
             if likeState {
                 firstList[indexPath.item].isLiked = false
@@ -385,7 +386,7 @@ extension FeedVC: FeedCellDelegate {
                 sixthList[indexPath.item].likeNum -= 1
             } else {
                 sixthList[indexPath.item].isLiked = true
-                sixthList[indexPath.item].likeNum -= 1
+                sixthList[indexPath.item].likeNum += 1
             }
         } else if indexPath.section == 6 {
             if likeState {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -398,7 +398,7 @@ extension FeedVC: FeedCellDelegate {
             }
         }
          
-        collectionView.reloadData()
+//        collectionView.reloadData()
         postFeedLikeWithAPI(recordID: recordID)
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#210

🌱 작업한 내용
- 피드 done 태그 찌그러지는 문제 수정
- 피드 좋아요 로티 함수 분리
- 피드 좋아요 문제 해결 못함..

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
좋아요 로티가 자기 멋대로 발동하고 있습니다..
어떤 경우 문제가 발생하는지 파악하려고 이것 저것 좋아요 누르다가 어떨 때 문제가 생기는지는 찾았는데, 근데 아직 머가 문제인지 정확하게는 모르겠습니다...
처음에는 cell reuse 문제인가 해서 prepareForReuse에 likeState = true 를 해줘보기도 했는데 이게 문제가 아닌 것 같습니다..
FeedVC에서 likeNum이랑 isLiked를 변경해주는데 그게 반영이 안되어서 그러는 것인지도 생각했는데.....😧
또 혹시나 indexPath가 먼가 꼬인 문제일까 해서 indexPath도 FeedCVC의 setLikeLottie를 실행시켜주는 부분에 함께 찍어봤었는데, indexPath는 정상적으로 찍혔습니다..

###### 흠 어디 좋아요를 누르는 것인지가 잘 보이지 않네요....
![ezgif com-gif-maker (45)](https://user-images.githubusercontent.com/81167570/151525405-26ca2faa-ad80-4253-be49-ba4430febebd.gif)
이상한 것을 정리해보자면..

> 1. 하나의 셀만 보일 때는 좋아요 로티가 작동하지 않던게 조금 스크롤 올려서 두개의 셀이 보이게 되면 잘 작동되는 경우
> 2. 두개의 셀이 보이게 스크롤을 조절해둔 뒤, 좋아요를 아래 셀의 하트를 눌렀을 때 위의 셀에서 하트 로티가 작동되는 경우..

setLikeLottie 함수는 아래처럼, 
함수를 실행했을 때 addSubview 하고, play한 뒤 stop, removeFromSuperview를 하도록 했습니다.
매번 play 안의 print는 정상적으로 실행되는 모습을 보입니다..
```
private func setLikeLottie() {
        self.addSubview(lottieView)

        lottieView.snp.makeConstraints { make in
            make.center.equalTo(likeButton.snp.center)
            make.width.height.equalTo(40)
        }

        lottieView.center = likeButton.center
        lottieView.loopMode = .playOnce
        lottieView.contentMode = .scaleAspectFit
        lottieView.layer.masksToBounds = true
        lottieView.play {_ in
            print("되는거여?🤬")
            self.lottieView.stop()
            self.lottieView.removeFromSuperview()
        }
    }
```

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 좋아요 로티 | 위에서.. 확인 부탁. |

## 📮 관련 이슈
- Resolved: #210 
