### PR TITLE
[Feat] #214 - 대기방에서 스와이프 pop

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -92,9 +92,11 @@ class WaitingVC: UIViewController {
             self.getWaitingRoomWithAPI(roomID: self.roomId ?? 0)
         }
     }
-    
+
     // MARK: - Methods
     private func setNavigation(title: String) {
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
+        
         switch fromWhereStatus {
         case .fromHome:
             navigationController?.initWithTwoCustomButtonsTitle(navigationItem: self.navigationItem,


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#214

🌱 작업한 내용
- 대기방에서 스와이프해서 pop 구현

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
현재 
`navigationController?.interactivePopGestureRecognizer?.delegate = nil`
코드를 통해서 네비바가 히든되어있을 때 스와이프 pop 을 구현하고 있는데요!

대기방의 경우는 뒤로가기 버튼이 있음에도 불구하고 위의 코드를 구현해야했어요!
> 네비바가 히든된 경우만 스와이프 pop 이 되지 않음

 ~그 이유가 현재 대기방은~

```swift
navigationController?.initWithTwoCustomButtonsTitle(navigationItem: self.navigationItem,
                                                                title: "\(title)",
                                                                tintColor: .sparkBlack,
                                                                backgroundColor: .sparkWhite,
                                                                reftButtonImage: UIImage(named: "icBackWhite"),
                                                                rightButtonImage: UIImage(),
                                                                reftButtonSelector: #selector(popToHomeVC),
                                                                rightButtonSelector: #selector(touchToMore))
```
~이런식으로 네비바의 backbutton 을 사용하지 않는 모양입니다! 그래서 스와이프 pop 을 필요로 하는거 같아요. 우리 플젝에서 나머지 백버튼은 모두 initBackButton 으로 구현되고 있습니다~
인줄 알았는데 타이머를 인증하는 부분에서는 스와이프가 되는 모양새더라구여. 네비바가 지금 어지러운 상태라서.. 탭바가 구현되고 정리해보겠습니다..

- 지금 네비바를 히든하구 임의로 백버튼과 타이틀을 올려서 사용하는 경우가 있어서 상황에 따라서 통일되지 않게 사용되는거 같아요! 그래서 일단 네비바를 해결한다음에 이 부분도 리펙을 해볼까합니다!

## 📮 관련 이슈
- Resolved: #214
