### PR TITLE
[Fix] #221 - 보관함 인증사진 모아보기 REST 이미지 우측 정렬되는 이슈

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/StorageMore/StorageMore.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/StorageMore/StorageMore.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,14 +18,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bgLinegridForBlack" translatesAutoresizingMaskIntoConstraints="NO" id="CnB-Ou-x6s">
-                                <rect key="frame" x="0.0" y="64" width="414" height="832"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" name="sparkBlack"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="CnB-Ou-x6s" secondAttribute="trailing" id="Xh8-h2-Yat"/>
-                            <constraint firstItem="CnB-Ou-x6s" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="20" id="eFJ-nc-629"/>
+                            <constraint firstItem="CnB-Ou-x6s" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="eFJ-nc-629"/>
                             <constraint firstItem="CnB-Ou-x6s" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="jul-Iy-BnV"/>
                             <constraint firstAttribute="bottom" secondItem="CnB-Ou-x6s" secondAttribute="bottom" id="xio-tr-ibZ"/>
                         </constraints>

--- a/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.swift
@@ -23,6 +23,7 @@ class MoreStorageCVC: UICollectionViewCell {
         dDayLabel.textColor = .sparkGray
         dDayLabel.text = "D-day"
         certificationImage.layer.masksToBounds = true
+        certificationImage.contentMode = .scaleAspectFill
     }
     
     override func prepareForReuse() {
@@ -38,13 +39,10 @@ class MoreStorageCVC: UICollectionViewCell {
         switch status {
         case "DONE":
             certificationImage.updateImage(mainImage)
-            certificationImage.contentMode = .scaleAspectFill
         case "REST":
             certificationImage.image = UIImage(named: "stickerRestBigMybox")
-            certificationImage.contentMode = .center
         default:
             certificationImage.image = UIImage(named: "tagEmptyBox")
-            certificationImage.contentMode = .scaleAspectFill
         }
         
         sparkCountLabel.text = String(sparkCount)

--- a/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.xib
+++ b/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,29 +12,29 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="MoreStorageCVC" customModule="Spark_iOS" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="160" height="203"/>
+            <rect key="frame" x="0.0" y="0.0" width="116" height="203"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="160" height="203"/>
+                <rect key="frame" x="0.0" y="0.0" width="116" height="203"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bjP-XQ-8o4">
-                        <rect key="frame" x="0.0" y="0.0" width="160" height="203"/>
+                        <rect key="frame" x="0.0" y="44" width="116" height="159"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bgLogin" translatesAutoresizingMaskIntoConstraints="NO" id="ywz-cO-r8W">
-                                <rect key="frame" x="0.0" y="0.0" width="160" height="160"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ywz-cO-r8W">
+                                <rect key="frame" x="0.0" y="0.0" width="116" height="116"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="ywz-cO-r8W" secondAttribute="height" multiplier="1:1" id="UsK-Vq-hro"/>
+                                    <constraint firstAttribute="width" secondItem="ywz-cO-r8W" secondAttribute="height" id="UsK-Vq-hro"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ClD-wt-IXN">
-                                <rect key="frame" x="0.0" y="164" width="41.5" height="20.5"/>
+                                <rect key="frame" x="0.0" y="120" width="41.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="ycO-Hf-3fL">
-                                <rect key="frame" x="133" y="165" width="24" height="18.5"/>
+                                <rect key="frame" x="89" y="121" width="24" height="18.5"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icFire" translatesAutoresizingMaskIntoConstraints="NO" id="58U-MR-Az4">
                                         <rect key="frame" x="0.0" y="3.5" width="12" height="12"/>
@@ -56,11 +56,11 @@
                         <constraints>
                             <constraint firstItem="ycO-Hf-3fL" firstAttribute="centerY" secondItem="ClD-wt-IXN" secondAttribute="centerY" id="1PM-FG-jx8"/>
                             <constraint firstAttribute="trailing" secondItem="ycO-Hf-3fL" secondAttribute="trailing" constant="3" id="3lC-Cz-1Kg"/>
-                            <constraint firstItem="ywz-cO-r8W" firstAttribute="top" secondItem="bjP-XQ-8o4" secondAttribute="top" id="Amb-ll-C4v"/>
-                            <constraint firstItem="ywz-cO-r8W" firstAttribute="height" secondItem="bjP-XQ-8o4" secondAttribute="height" multiplier="0.788177" id="eNL-2D-Qrl"/>
-                            <constraint firstItem="ClD-wt-IXN" firstAttribute="leading" secondItem="ywz-cO-r8W" secondAttribute="leading" id="iIr-zs-vWP"/>
-                            <constraint firstItem="ywz-cO-r8W" firstAttribute="leading" secondItem="bjP-XQ-8o4" secondAttribute="leading" id="pOK-wx-yUc"/>
-                            <constraint firstItem="ClD-wt-IXN" firstAttribute="top" secondItem="ywz-cO-r8W" secondAttribute="bottom" constant="4" id="qqw-Pl-XoM"/>
+                            <constraint firstItem="ClD-wt-IXN" firstAttribute="leading" secondItem="bjP-XQ-8o4" secondAttribute="leading" id="GYK-vC-2sp"/>
+                            <constraint firstItem="ywz-cO-r8W" firstAttribute="top" secondItem="bjP-XQ-8o4" secondAttribute="top" id="Icm-8u-ddO"/>
+                            <constraint firstAttribute="trailing" secondItem="ywz-cO-r8W" secondAttribute="trailing" id="X4R-sL-qW3"/>
+                            <constraint firstItem="ClD-wt-IXN" firstAttribute="top" secondItem="ywz-cO-r8W" secondAttribute="bottom" constant="4" id="Yxc-PA-b7b"/>
+                            <constraint firstItem="ywz-cO-r8W" firstAttribute="leading" secondItem="bjP-XQ-8o4" secondAttribute="leading" id="u7H-Cq-VLb"/>
                         </constraints>
                     </view>
                 </subviews>
@@ -68,20 +68,20 @@
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
                 <constraint firstItem="ZTg-uK-7eu" firstAttribute="bottom" secondItem="bjP-XQ-8o4" secondAttribute="bottom" id="1mg-Ka-IVX"/>
-                <constraint firstItem="ZTg-uK-7eu" firstAttribute="top" secondItem="bjP-XQ-8o4" secondAttribute="top" constant="44" id="FWz-62-mOG"/>
+                <constraint firstItem="ZTg-uK-7eu" firstAttribute="top" secondItem="bjP-XQ-8o4" secondAttribute="top" id="FWz-62-mOG"/>
                 <constraint firstItem="bjP-XQ-8o4" firstAttribute="leading" secondItem="ZTg-uK-7eu" secondAttribute="leading" id="I0c-Dh-gqf"/>
                 <constraint firstItem="ZTg-uK-7eu" firstAttribute="trailing" secondItem="bjP-XQ-8o4" secondAttribute="trailing" id="WOp-Sl-3RF"/>
             </constraints>
+            <size key="customSize" width="116" height="203"/>
             <connections>
                 <outlet property="certificationImage" destination="ywz-cO-r8W" id="Dh5-68-KEp"/>
                 <outlet property="dDayLabel" destination="ClD-wt-IXN" id="Bgm-uB-6Hz"/>
                 <outlet property="sparkCountLabel" destination="5no-YH-587" id="KTy-fw-Ske"/>
             </connections>
-            <point key="canvasLocation" x="137.68115942028987" y="153.01339285714286"/>
+            <point key="canvasLocation" x="105.79710144927537" y="142.96875"/>
         </collectionViewCell>
     </objects>
     <resources>
-        <image name="bgLogin" width="375" height="812"/>
         <image name="icFire" width="12" height="12"/>
         <namedColor name="sparkGray">
             <color red="0.6940000057220459" green="0.69800001382827759" blue="0.70599997043609619" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -96,20 +96,25 @@ extension StorageMoreVC {
 
 extension StorageMoreVC: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let cellWidth: CGFloat = collectionView.frame.width
-        let cellWidthRatio: CGFloat = 160/375
-        let widthHeightRatio: CGFloat = 203/160
-        let cell = CGSize(width: cellWidth*cellWidthRatio, height: cellWidth*cellWidthRatio*widthHeightRatio)
+        // 양쪽 inset 40 + inter item spacing 15
+        let cellWidth: CGFloat = (collectionView.frame.width - 55) / 2
+        let cellHeight: CGFloat = (cellWidth * (187/160))
+        
+        let cell = CGSize(width: cellWidth, height: cellHeight)
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        let insets = UIEdgeInsets(top: 20, left: 20, bottom: 0, right: 20)
+        let insets = UIEdgeInsets(top: 30, left: 20, bottom: 0, right: 20)
         return insets
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 15
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 16
     }
 }
 


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#221

🌱 작업한 내용
- 보관함 인증사진 모아보기에서 우측으로 정렬되는 이슈를 해결했다.
- MoreStroageCVC Xib 오토레이아웃을 수정했습니다

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 아래와 같이 셀사이즈를 기기가 바뀌어도 가로 사이 간격은 15을 유지하면서 187:160 비율을 지키도록 코드를 짜보았어요!
> 기존에 세로간격없이 꽉차있던것을  세로 간격은 16으로 추가했습니다! 이유는 준호한테 이런코드도 있다고 보여주고 싶었어용! 그때 말했던것처럼 간격역시 기기대응에서 비율로 가져갈건지 저처럼 16으로 가져갈건지에 대한 차이입니다!

```swift
// 양쪽 inset 40 + inter item spacing 15
        let cellWidth: CGFloat = (collectionView.frame.width - 55) / 2
        let cellHeight: CGFloat = (cellWidth * (187/160))
        
        let cell = CGSize(width: cellWidth, height: cellHeight)
        return cell
```
- 제플린
<img width="379" alt="스크린샷 2022-01-29 오후 5 27 16" src="https://user-images.githubusercontent.com/69136340/151654052-a9238caf-d3fa-44bb-b510-5f1de47d47a4.png">

- MoreStorageCVC 수정
> superview 에 대해서 이미지뷰가 비율로 잡혀있었어요 아래 보는것처럼 = 표시가 세로에 있죵? 지워줬습니다 그리고 1대1이라서 괜찮지만 의도를 나타내기 위해서 상단과 좌우를 슈퍼뷰와 컨스트레인트를 잡아주었습니다.

<img width="675" alt="스크린샷 2022-01-29 오후 4 57 27" src="https://user-images.githubusercontent.com/69136340/151654080-c92529fe-14c4-4305-8bfa-ccc5b2bc6f8e.png">


- 문제해결
> 아래처럼 안전영역 밖으로 잡혀있었어요!

<img width="289" alt="스크린샷 2022-01-29 오후 5 19 56" src="https://user-images.githubusercontent.com/69136340/151654084-a53f2d8b-c78a-4d59-8fcc-57d2b7d761fb.png">

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|결과|<img src="https://user-images.githubusercontent.com/69136340/151654022-2419cb4d-8140-40ce-b9c3-76bafcb78e2d.png" width ="250">|

## 📮 관련 이슈
- Resolved: #221
