### PR TITLE
[Fix] #223 - 대기방에서 홈으로 이동시 플로팅 버튼 띄우기

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -103,7 +103,7 @@
 		F8096F3227841FE100B71D38 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F3127841FE100B71D38 /* ViewController.swift */; };
 		F8096F3C2784211D00B71D38 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F3B2784211D00B71D38 /* UIColor+.swift */; };
 		F8096F3E2784213700B71D38 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F3D2784213700B71D38 /* UIFont+.swift */; };
-		F8096F442784221900B71D38 /* Xib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F432784221900B71D38 /* Xib.swift */; };
+		F8096F442784221900B71D38 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F432784221900B71D38 /* Cell.swift */; };
 		F8096F462784247100B71D38 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8096F452784247100B71D38 /* Notification.swift */; };
 		F80A3E4D278C182100728E07 /* MainTabBar.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F80A3E4C278C182100728E07 /* MainTabBar.storyboard */; };
 		F80A3E4F278C18BA00728E07 /* MainTBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80A3E4E278C18BA00728E07 /* MainTBC.swift */; };
@@ -249,7 +249,7 @@
 		F8096F3127841FE100B71D38 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		F8096F3B2784211D00B71D38 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		F8096F3D2784213700B71D38 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
-		F8096F432784221900B71D38 /* Xib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Xib.swift; sourceTree = "<group>"; };
+		F8096F432784221900B71D38 /* Cell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
 		F8096F452784247100B71D38 /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		F80A3E4C278C182100728E07 /* MainTabBar.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainTabBar.storyboard; sourceTree = "<group>"; };
 		F80A3E4E278C18BA00728E07 /* MainTBC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTBC.swift; sourceTree = "<group>"; };
@@ -739,7 +739,7 @@
 				F8096F2A27841F4100B71D38 /* Storyboard.swift */,
 				EBEA383827953BC700B5736A /* Lottie.swift */,
 				F8096F3127841FE100B71D38 /* ViewController.swift */,
-				F8096F432784221900B71D38 /* Xib.swift */,
+				F8096F432784221900B71D38 /* Cell.swift */,
 				F8096F452784247100B71D38 /* Notification.swift */,
 				F82B2E0A278EBC4400219628 /* UserDefaultsKey.swift */,
 				F82F57FE27928588003E4174 /* URL.swift */,
@@ -1216,7 +1216,7 @@
 				EB874AEB279706FC000DD20B /* DialogueVC.swift in Sources */,
 				2BBED13027956C9F0052CA5C /* Feed.swift in Sources */,
 				F8F6D6FE2797D8BD00725537 /* HabitRoomDetail.swift in Sources */,
-				F8096F442784221900B71D38 /* Xib.swift in Sources */,
+				F8096F442784221900B71D38 /* Cell.swift in Sources */,
 				F86C68B727955ABA009A5296 /* SparkFlake.swift in Sources */,
 				EB625E8A278F29D300C43DE9 /* CarouselLayout.swift in Sources */,
 				F82F57FF27928588003E4174 /* URL.swift in Sources */,

--- a/Spark-iOS/Spark-iOS/Resource/Constants/Cell.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Cell.swift
@@ -9,8 +9,8 @@ import Foundation
 
 extension Const {
     /// 셀 혹은 커스텀 뷰 Xib 의 nibName 을 상수로 관리합니다.
-    struct Xib {
-        struct NibName {
+    struct Cell {
+        struct Identifier {
             static let doingStorageCVC = "DoingStorageCVC"
             static let doneStorageCVC = "DoneStorageCVC"
             static let failStorageCVC = "FailStorageCVC"
@@ -19,6 +19,7 @@ extension Const {
             static let homeWaitingCVC = "HomeWaitingCVC"
             static let homeEmptyCVC = "HomeEmptyCVC"
             static let habitRoomMemeberCVC = "HabitRoomMemberCVC"
+            static let waitingFriendCVC = "WaitingFriendCVC"
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Cells/Waiting/WaitingFriendCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Waiting/WaitingFriendCVC.swift
@@ -10,9 +10,9 @@ import UIKit
 import SnapKit
 
 class WaitingFriendCVC: UICollectionViewCell {
-    static let identifier = "WaitingFriendCVC"
     
     // MARK: - Properties
+    
     let profileImageView = UIImageView()
     let nameLabel = UILabel()
     
@@ -20,6 +20,7 @@ class WaitingFriendCVC: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
         setUI()
         setLayout()
     }
@@ -32,9 +33,12 @@ class WaitingFriendCVC: UICollectionViewCell {
         nameLabel.text = ""
         profileImageView.image = UIImage()
     }
-    
-    // MARK: - Methods
-    func setUI() {
+}
+
+// MARK: - Methods
+
+extension WaitingFriendCVC {
+    private func setUI() {
         profileImageView.backgroundColor = .sparkGray
         profileImageView.layer.borderWidth = 2
         profileImageView.layer.borderColor = UIColor.sparkWhite.cgColor
@@ -49,7 +53,7 @@ class WaitingFriendCVC: UICollectionViewCell {
         nameLabel.textAlignment = .center
     }
     
-    func setLayout() {
+    private func setLayout() {
         addSubviews([profileImageView, nameLabel])
         
         profileImageView.snp.makeConstraints { make in
@@ -64,8 +68,9 @@ class WaitingFriendCVC: UICollectionViewCell {
         }
     }
     
+    /// 셀 초기화.
     func initCell(name: String, imagePath: String) {
-            nameLabel.text = name
-            profileImageView.updateImage(imagePath)
-        }
+        nameLabel.text = name
+        profileImageView.updateImage(imagePath)
+    }
 }

--- a/Spark-iOS/Spark-iOS/Source/Cells/Waiting/WaitingFriendCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Waiting/WaitingFriendCVC.swift
@@ -41,7 +41,7 @@ extension WaitingFriendCVC {
     private func setUI() {
         profileImageView.backgroundColor = .sparkGray
         profileImageView.layer.borderWidth = 2
-        profileImageView.layer.borderColor = UIColor.sparkWhite.cgColor
+        profileImageView.layer.borderColor = UIColor.sparkLightGray.cgColor
         profileImageView.layer.cornerRadius = 30
         profileImageView.layer.masksToBounds = true
         profileImageView.contentMode = .scaleAspectFill

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -271,7 +271,7 @@ extension HabitRoomVC {
     }
     
     private func registerXib() {
-        mainCollectionView.register(UINib(nibName: Const.Xib.NibName.habitRoomMemeberCVC, bundle: nil), forCellWithReuseIdentifier: Const.Xib.NibName.habitRoomMemeberCVC)
+        mainCollectionView.register(UINib(nibName: Const.Cell.Identifier.habitRoomMemeberCVC, bundle: nil), forCellWithReuseIdentifier: Const.Cell.Identifier.habitRoomMemeberCVC)
     }
 
     func showAlert() {
@@ -389,7 +389,7 @@ extension HabitRoomVC: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.NibName.habitRoomMemeberCVC, for: indexPath) as? HabitRoomMemberCVC else { return UICollectionViewCell() }
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.habitRoomMemeberCVC, for: indexPath) as? HabitRoomMemberCVC else { return UICollectionViewCell() }
         if indexPath.item == 0 {
             cell.initCellMe(recordID: habitRoomDetail?.myRecord.recordID ?? 0,
                             userID: habitRoomDetail?.myRecord.userID ?? 0,

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -128,7 +128,7 @@ extension StorageMoreVC: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.NibName.moreStorageCVC, for: indexPath) as? MoreStorageCVC else {return UICollectionViewCell()}
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.moreStorageCVC, for: indexPath) as? MoreStorageCVC else {return UICollectionViewCell()}
         
         cell.initCell(leftDay: myRoomCertificationList?[indexPath.row].leftDay ?? 0,
                       mainImage: myRoomCertificationList?[indexPath.row].certifyingImg ?? "",

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -90,9 +90,9 @@ extension HomeVC {
     }
     
     private func registerXib() {
-        mainCollectionView.register(UINib(nibName: Const.Xib.NibName.homeHabitCVC, bundle: nil), forCellWithReuseIdentifier: Const.Xib.NibName.homeHabitCVC)
-        mainCollectionView.register(UINib(nibName: Const.Xib.NibName.homeWaitingCVC, bundle: nil), forCellWithReuseIdentifier: Const.Xib.NibName.homeWaitingCVC)
-        mainCollectionView.register(UINib(nibName: Const.Xib.NibName.homeEmptyCVC, bundle: nil), forCellWithReuseIdentifier: Const.Xib.NibName.homeEmptyCVC)
+        mainCollectionView.register(UINib(nibName: Const.Cell.Identifier.homeHabitCVC, bundle: nil), forCellWithReuseIdentifier: Const.Cell.Identifier.homeHabitCVC)
+        mainCollectionView.register(UINib(nibName: Const.Cell.Identifier.homeWaitingCVC, bundle: nil), forCellWithReuseIdentifier: Const.Cell.Identifier.homeWaitingCVC)
+        mainCollectionView.register(UINib(nibName: Const.Cell.Identifier.homeEmptyCVC, bundle: nil), forCellWithReuseIdentifier: Const.Cell.Identifier.homeEmptyCVC)
     }
     
     private func setLoading() {
@@ -179,13 +179,13 @@ extension HomeVC: UICollectionViewDataSource {
         if habitRoomList.count != 0 {
             collectionView.isScrollEnabled = true
             if habitRoomList[indexPath.item].isStarted == false {
-                guard let waitingCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.NibName.homeWaitingCVC, for: indexPath) as? HomeWaitingCVC else { return UICollectionViewCell() }
+                guard let waitingCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.homeWaitingCVC, for: indexPath) as? HomeWaitingCVC else { return UICollectionViewCell() }
                 
                 waitingCVC.initCell(roomName: habitRoomList[indexPath.item].roomName)
                 
                 return waitingCVC
             } else {
-                guard let habitCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.NibName.homeHabitCVC, for: indexPath) as? HomeHabitCVC else { return UICollectionViewCell() }
+                guard let habitCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.homeHabitCVC, for: indexPath) as? HomeHabitCVC else { return UICollectionViewCell() }
                 
                 habitCVC.initCell(roomName: habitRoomList[indexPath.item].roomName,
                                   leftDay: habitRoomList[indexPath.item].leftDay ?? 0,
@@ -200,7 +200,7 @@ extension HomeVC: UICollectionViewDataSource {
         } else {
             // empty view.
             collectionView.isScrollEnabled = false
-            guard let emptyCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.NibName.homeEmptyCVC, for: indexPath) as? HomeEmptyCVC else { return UICollectionViewCell()}
+            guard let emptyCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.homeEmptyCVC, for: indexPath) as? HomeEmptyCVC else { return UICollectionViewCell()}
 
             return emptyCVC
         }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
@@ -456,7 +456,7 @@ extension StorageVC: UICollectionViewDelegate, UICollectionViewDataSource {
         case DoingCV:
             guard let onGoingRoomList = onGoingRoomList else { return UICollectionViewCell()}
             
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.NibName.doingStorageCVC, for: indexPath) as? DoingStorageCVC else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.doingStorageCVC, for: indexPath) as? DoingStorageCVC else { return UICollectionViewCell() }
             
             cell.initCell(roomName: onGoingRoomList[indexPath.row].roomName,
                           leftDay: onGoingRoomList[indexPath.row].leftDay,
@@ -471,7 +471,7 @@ extension StorageVC: UICollectionViewDelegate, UICollectionViewDataSource {
         case DoneCV:
             guard let completeRoomList = completeRoomList else { return UICollectionViewCell()}
             
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.NibName.doneStorageCVC, for: indexPath) as? DoneStorageCVC else { return UICollectionViewCell()}
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.doneStorageCVC, for: indexPath) as? DoneStorageCVC else { return UICollectionViewCell()}
             
             cell.initCell(roomName: completeRoomList[indexPath.row].roomName,
                           thumbnail: completeRoomList[indexPath.row].thumbnail,
@@ -485,7 +485,7 @@ extension StorageVC: UICollectionViewDelegate, UICollectionViewDataSource {
         default:
             guard let failRoomList = failRoomList else { return UICollectionViewCell()}
             
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Xib.NibName.failStorageCVC, for: indexPath) as? FailStorageCVC else { return UICollectionViewCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.failStorageCVC, for: indexPath) as? FailStorageCVC else { return UICollectionViewCell() }
             
             cell.initCell(roomName: failRoomList[indexPath.row].roomName,
                           leftDay: failRoomList[indexPath.row].failDay ?? 0,

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -318,6 +318,7 @@ class WaitingVC: UIViewController {
     @objc
     func dismissJoinCodeToHomeVC() {
         presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true)
+        NotificationCenter.default.post(name: .appearFloatingButton, object: nil)
     }
     
     @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -71,6 +71,7 @@ class WaitingVC: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         setUI()
         setLayout()
         setCollectionView()
@@ -92,8 +93,11 @@ class WaitingVC: UIViewController {
             self.getWaitingRoomWithAPI(roomID: self.roomId ?? 0)
         }
     }
+}
 
-    // MARK: - Methods
+// MARK: - Methods
+
+extension WaitingVC {
     private func setNavigation(title: String) {
         navigationController?.interactivePopGestureRecognizer?.delegate = nil
         
@@ -236,7 +240,7 @@ class WaitingVC: UIViewController {
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.delegate = self
         collectionView.dataSource = self
-        collectionView.register(WaitingFriendCVC.self, forCellWithReuseIdentifier: WaitingFriendCVC.identifier)
+        collectionView.register(WaitingFriendCVC.self, forCellWithReuseIdentifier: Const.Cell.Identifier.waitingFriendCVC)
         
         collectionViewFlowLayout.scrollDirection = .horizontal
     }
@@ -244,26 +248,36 @@ class WaitingVC: UIViewController {
     private func refreshButtonAnimtation() {
         UIView.animate(withDuration: 0.4,
                        delay: 0.1,
-                       options: .curveEaseInOut) {
+                       options: .curveEaseInOut,
+                       animations: {
             let rotate = CGAffineTransform(rotationAngle: -3.14)
             self.refreshButton.transform = rotate
-        } completion: { _ in
+        },
+                       completion: { _ in
             self.refreshButton.transform = .identity
-        }
+        })
     }
     
     private func presentToolTip() {
-        UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseIn, animations: {
+        UIView.animate(withDuration: 0.2,
+                       delay: 0,
+                       options: .curveEaseIn,
+                       animations: {
             self.toolTipImageView.transform = CGAffineTransform.identity
             self.toolTipImageView.alpha = 1
-        }, completion: nil)
+        },
+                       completion: nil)
     }
     
     private func dismissToolTip() {
-        UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseIn, animations: {
+        UIView.animate(withDuration: 0.2,
+                       delay: 0,
+                       options: .curveEaseIn,
+                       animations: {
             self.toolTipImageView.transform = CGAffineTransform.identity
             self.toolTipImageView.alpha = 0
-        }, completion: nil)
+        },
+                       completion: nil)
     }
     
     private func setGestureRecognizer() {
@@ -272,13 +286,13 @@ class WaitingVC: UIViewController {
     }
     
     @objc
-    func copyToClipboard() {
+    private func copyToClipboard() {
         UIPasteboard.general.string = roomCode
         showToast(x: 20, y: startButton.frame.minY - 60, message: "코드를 복사했어요", font: .p1TitleLight)
     }
     
     @objc
-    func touchEditButton() {
+    private func touchEditButton() {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.goalWriting, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.goalWriting) as? GoalWritingVC else { return }
         
         nextVC.modalPresentationStyle = .fullScreen
@@ -306,34 +320,36 @@ class WaitingVC: UIViewController {
     // MARK: - 화면 전환
     
     @objc
-    func popToHomeVC() {
+    private func popToHomeVC() {
         navigationController?.popViewController(animated: true)
     }
     
     @objc
-    func dismissToHomeVC() {
+    private func dismissToHomeVC() {
         presentingViewController?.presentingViewController?.dismiss(animated: true)
     }
     
     @objc
-    func dismissJoinCodeToHomeVC() {
+    private func dismissJoinCodeToHomeVC() {
         presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true)
         NotificationCenter.default.post(name: .appearFloatingButton, object: nil)
     }
     
     @objc
-    func touchToMore() {
-           // 더보기 버튼
+    private func touchToMore() {
+        
+        // TODO: - 더보기 버튼
+        
     }
     
     @objc
-    func touchToRefreshButton() {
+    private func touchToRefreshButton() {
         refreshButtonAnimtation()
         getWaitingMembersWithAPI(roomID: roomId ?? 0)
     }
     
     @objc
-    func touchToCreateButton() {
+    private func touchToCreateButton() {
         DispatchQueue.main.async {
             self.setLoading()
         }
@@ -359,12 +375,13 @@ class WaitingVC: UIViewController {
 // MARK: - Network
 
 extension WaitingVC {
-    func getWaitingRoomWithAPI(roomID: Int) {
+    private func getWaitingRoomWithAPI(roomID: Int) {
         RoomAPI.shared.waitingFetch(roomID: roomID) { response in
             switch response {
             case .success(let data):
                 self.loadingView.stop()
                 self.loadingBgView.removeFromSuperview()
+                
                 if let waitingRoom = data as? Waiting {
                     var user: ReqUser
                     
@@ -431,17 +448,14 @@ extension WaitingVC {
         }
     }
     
-    func getWaitingMembersWithAPI(roomID: Int) {
+    private func getWaitingMembersWithAPI(roomID: Int) {
         RoomAPI.shared.waitingMemberFetch(roomID: roomID) { response in
             switch response {
             case .success(let data):
                 if let waitingMembers = data as? WaitingMember {
                     
-                    // 기존 스파커 삭제 & 다시 데이터 추가
-                    self.members.removeAll()
-                    self.members.append(contentsOf: waitingMembers.members)
-                    
-                    // 스파커 멤버 수
+                    // 대기방 멤버 갱신.
+                    self.members = waitingMembers.members
                     self.friendCountLabel.text = "\(self.members.count)"
                     
                     self.collectionView.reloadData()
@@ -458,13 +472,14 @@ extension WaitingVC {
         }
     }
     
-    func postStartRoomWithAPI(roomID: Int, completion: @escaping () -> Void) {
+    private func postStartRoomWithAPI(roomID: Int, completion: @escaping () -> Void) {
         RoomAPI.shared.startRoomWithAPI(roomID: roomID) { response in
             switch response {
             case .success(let message):
-                completion()
                 self.loadingView.stop()
                 self.loadingBgView.removeFromSuperview()
+                
+                completion()
                 print("postStartRoomWithAPI - success: \(message)")
             case .requestErr(let message):
                 print("postStartRoomWithAPI - requestErr: \(message)")
@@ -487,7 +502,7 @@ extension WaitingVC: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: WaitingFriendCVC.identifier, for: indexPath) as? WaitingFriendCVC else { return UICollectionViewCell() }
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.waitingFriendCVC, for: indexPath) as? WaitingFriendCVC else { return UICollectionViewCell() }
         
         let name = members[indexPath.item].nickname
         let imagePath = members[indexPath.item].profileImg ?? ""
@@ -519,6 +534,7 @@ extension WaitingVC: UICollectionViewDelegateFlowLayout {
 }
 
 // MARK: - Layout
+
 extension WaitingVC {
     func setLayout() {
         view.addSubviews([copyButton, checkTitleLabel, toolTipButton,
@@ -645,7 +661,7 @@ extension WaitingVC {
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
             make.width.equalToSuperview().inset(20)
-            make.height.equalTo(self.view.frame.width*48/335)
+            make.height.equalTo(self.view.frame.width * 48 / 335)
         }
     }
 }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#223

🌱 작업한 내용
- 코드로 방 참여 플로우에서 대기방에서 홈으로 이동시 플로팅 버튼 띄우기

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
> 해당 이슈 #223 참조

### 리펙

- 이외에도 WaitingVC 를 컨밴션에 맞춰서 조금 수정했어요!

원래는 마지막 클로저 매개변수는 이름을 적어주지 않는것이 컨밴션이어서 적어주지 않으니 
https://realm.github.io/SwiftLint/multiple_closures_with_trailing_closure.html 경고 등장!
후행클로저가 두개이상인 경우 매개변수명을 다 적어줘야한다고해서 변경해두었습니다.

```swift
    private func refreshButtonAnimtation() {
        UIView.animate(withDuration: 0.4,
                       delay: 0.1,
                       options: .curveEaseInOut,
                       animations: {
            let rotate = CGAffineTransform(rotationAngle: -3.14)
            self.refreshButton.transform = rotate
        },
                       completion: { _ in
            self.refreshButton.transform = .identity
        })
    }
```

- WaitingFriendCVC 접근제어자 설정 및 extensions 분리, identifier 제거 후 Const 로 관리
- WaitingVC 접근제어자 설정
- Xib 폴더 Cell 로 변경해서 코드베이스의 경우도 identifier 를 const 로 관리하도록 함
- 스위프트린트에 맞춰서 다중 후행클로저 수정

### 추가
- 대기방 멤버 테두리 색변경

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|플로팅버튼|<img src="https://user-images.githubusercontent.com/69136340/151697266-1d09dbf9-1182-441a-bd89-9c660ae53277.mp4" width="250">|

## 📮 관련 이슈
- Resolved: #223