### PR TITLE
[Feat] #231 - 스파크 보내기 시 햅틱 구현

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		F82F580C27929F74003E4174 /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82F580B27929F74003E4174 /* Header.swift */; };
 		F82F580E27930FD4003E4174 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F82F580D27930FD4003E4174 /* GoogleService-Info.plist */; };
 		F82F58112793B3FF003E4174 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = F82F58102793B3FF003E4174 /* .swiftlint.yml */; };
+		F8404E8B27AB835F004AEDC3 /* SendSparkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8404E8A27AB835F004AEDC3 /* SendSparkButton.swift */; };
 		F867B6B6278F86610024B1D4 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F867B6B5278F86610024B1D4 /* UINavigationController+.swift */; };
 		F86C68B727955ABA009A5296 /* SparkFlake.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86C68B627955ABA009A5296 /* SparkFlake.swift */; };
 		F86C68B927958AA9009A5296 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F86C68B827958AA9009A5296 /* UIImageView+.swift */; };
@@ -273,6 +274,7 @@
 		F82F580D27930FD4003E4174 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F82F58102793B3FF003E4174 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		F8368FAA278F5DFF00110B74 /* Spark-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Spark-iOS.entitlements"; sourceTree = "<group>"; };
+		F8404E8A27AB835F004AEDC3 /* SendSparkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendSparkButton.swift; sourceTree = "<group>"; };
 		F867B6B5278F86610024B1D4 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		F86C68B627955ABA009A5296 /* SparkFlake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkFlake.swift; sourceTree = "<group>"; };
 		F86C68B827958AA9009A5296 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
@@ -538,6 +540,7 @@
 				2BE5D80D2793203C007A544D /* Stopwatch.swift */,
 				EBE90FDD2796C45900157075 /* StatusButton.swift */,
 				F86C68B627955ABA009A5296 /* SparkFlake.swift */,
+				F8404E8A27AB835F004AEDC3 /* SendSparkButton.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1249,6 +1252,7 @@
 				F82F57FB27928437003E4174 /* NetworkResult.swift in Sources */,
 				F82F5802279287FD003E4174 /* HabitRoom.swift in Sources */,
 				F82B2E12278F54CD00219628 /* SplashVC.swift in Sources */,
+				F8404E8B27AB835F004AEDC3 /* SendSparkButton.swift in Sources */,
 				F82F580427928975003E4174 /* MoyaLoggerPlugin.swift in Sources */,
 				F8096F2927841F1E00B71D38 /* Const.swift in Sources */,
 				F86C68B927958AA9009A5296 /* UIImageView+.swift in Sources */,

--- a/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
@@ -8,5 +8,47 @@
 import UIKit
 
 class SendSparkButton: UIButton {
+    
+    // MARK: - Properties
+    
+//    enum
+    
+   // FIXME: - tag 로 대체
     public var identifier: Int = -1
+    
+    // MARK: - Initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public init() {
+        super.init(frame: .zero)
+        
+        setUI()
+    }
+    
+//    override var isSelected {
+//        didSet {
+//
+//        } else {
+//
+//        }
+//    }
+}
+
+// MARK: - Methods
+
+extension SendSparkButton {
+    private func setUI() {
+        self.layer.borderColor = UIColor.sparkLightPinkred.cgColor
+        self.layer.cornerRadius = 2
+        self.layer.borderWidth = 1
+        self.setTitleColor(.sparkLightPinkred, for: .normal)
+        self.titleLabel?.font = .krMediumFont(ofSize: 14)
+    }
 }

--- a/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
@@ -7,14 +7,17 @@
 
 import UIKit
 
+final
 class SendSparkButton: UIButton {
     
     // MARK: - Properties
     
-//    enum
-    
-   // FIXME: - tag 로 대체
-    public var identifier: Int = -1
+    public enum SendSparkStatus {
+        case first
+        case second
+        case third
+        case fourth
+    }
     
     // MARK: - Initialize
     
@@ -26,29 +29,50 @@ class SendSparkButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public init() {
+    public init(type: SendSparkStatus) {
         super.init(frame: .zero)
         
-        setUI()
+        setUI(type)
     }
-    
-//    override var isSelected {
-//        didSet {
-//
-//        } else {
-//
-//        }
-//    }
 }
 
 // MARK: - Methods
 
 extension SendSparkButton {
-    private func setUI() {
+    private func setUI(_ type: SendSparkStatus) {
         self.layer.borderColor = UIColor.sparkLightPinkred.cgColor
         self.layer.cornerRadius = 2
         self.layer.borderWidth = 1
         self.setTitleColor(.sparkLightPinkred, for: .normal)
         self.titleLabel?.font = .krMediumFont(ofSize: 14)
+        
+        switch type {
+        case .first:
+            self.setTitle("👊 아자아자 파이팅!", for: .normal)
+            self.tag = 1
+        case .second:
+            self.setTitle("🔥오늘 안 해? 같이 해!", for: .normal)
+            self.tag = 2
+        case .third:
+            self.setTitle("👉 너만 하면 돼!", for: .normal)
+            self.tag = 3
+        case .fourth:
+            self.setTitle("👍 얼마 안 남았어, 어서 하자!", for: .normal)
+            self.tag = 4
+        }
+    }
+    
+    public func isSelected(_ isSelected: Bool) {
+        if isSelected {
+            self.setTitleColor(.sparkDarkPinkred, for: .normal)
+            self.backgroundColor = .sparkMostLightPinkred
+            self.titleLabel?.backgroundColor = .sparkMostLightPinkred
+            self.layer.borderColor = UIColor.sparkDarkPinkred.cgColor
+        } else {
+            self.setTitleColor(.sparkLightPinkred, for: .normal)
+            self.backgroundColor = .sparkWhite
+            self.titleLabel?.backgroundColor = .sparkWhite
+            self.layer.borderColor = UIColor.sparkLightPinkred.cgColor
+        }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
@@ -7,8 +7,7 @@
 
 import UIKit
 
-final
-class SendSparkButton: UIButton {
+final class SendSparkButton: UIButton {
     
     // MARK: - Properties
     

--- a/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
@@ -1,0 +1,12 @@
+//
+//  SendSparkButton.swift
+//  Spark-iOS
+//
+//  Created by kimhyungyu on 2022/02/03.
+//
+
+import UIKit
+
+class SendSparkButton: UIButton {
+    public var identifier: Int = -1
+}

--- a/Spark-iOS/Spark-iOS/Source/Extensions/UIViewController+.swift
+++ b/Spark-iOS/Spark-iOS/Source/Extensions/UIViewController+.swift
@@ -68,7 +68,7 @@ extension UIViewController {
         
         self.view.addSubview(backgroundView)
         backgroundView.alpha = 0.0
-        UIView.animate(withDuration: 0.2, delay: 0.2,
+        UIView.animate(withDuration: 0.2, delay: 0,
                        options: .curveEaseInOut) {
             backgroundView.alpha = 1.0
         } completion: { _ in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -33,7 +33,7 @@ class SendSparkVC: UIViewController {
         super.viewDidLoad()
         setUI()
         setLayout()
-        setAddTargets(firstButton, secondButton, thirdButton, fourthButton)
+        setAddTargets()
     }
     
     // MARK: IBAction Properties
@@ -51,9 +51,9 @@ extension SendSparkVC {
         tabBarController?.tabBar.isHidden = true
     }
     
-    private func setAddTargets(_ buttons: UIButton...) {
-        for button in buttons {
-            button.addTarget(self, action: #selector(touchSendSparkButton(_:)), for: .touchUpInside)
+    private func setAddTargets() {
+        [firstButton, secondButton, thirdButton, fourthButton].forEach {
+            $0.addTarget(self, action: #selector(touchSendSparkButton(_:)), for: .touchUpInside)
         }
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -93,6 +93,7 @@ extension SendSparkVC {
         
         [firstButton, secondButton, thirdButton, fourthButton].forEach {
             if $0.identifier != sender.identifier {
+                // 통신실패 시 필요할듯.
                 $0.setTitleColor(.sparkLightPinkred, for: .normal)
                 $0.backgroundColor = .sparkWhite
                 $0.titleLabel?.backgroundColor = .sparkWhite

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -25,6 +25,8 @@ class SendSparkVC: UIViewController {
     private let thirdButtonText: String = "👉 너만 하면 돼!"
     private let fourthButtonText: String = "👍 얼마 안 남았어, 어서 하자!"
     
+    private var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
+    
     // MARK: IBoutlet properties
     
     @IBOutlet weak var popUpView: UIView!
@@ -78,11 +80,18 @@ extension SendSparkVC {
         }
     }
     
+    private func setFeedbackGenerator() {
+        selectionFeedbackGenerator = UISelectionFeedbackGenerator()
+        selectionFeedbackGenerator?.selectionChanged()
+    }
+    
     // MARK: - @objc Function
     
     @objc
     func setSelectedButton(_ sender: SendSparkButton) {
         [firstButton, secondButton, thirdButton, fourthButton].forEach {
+            setFeedbackGenerator()
+            
             if $0.identifier != sender.identifier {
                 $0.setTitleColor(.sparkLightPinkred, for: .normal)
                 $0.backgroundColor = .sparkWhite

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -15,10 +15,10 @@ class SendSparkVC: UIViewController {
     var recordID: Int?
     var userName: String?
     
-    var firstButton = SendSparkButton()
-    var secondButton = SendSparkButton()
-    var thirdButton = SendSparkButton()
-    var fourthButton = SendSparkButton()
+    private var firstButton = SendSparkButton()
+    private var secondButton = SendSparkButton()
+    private var thirdButton = SendSparkButton()
+    private var fourthButton = SendSparkButton()
     
     // MARK: IBoutlet properties
     
@@ -68,39 +68,6 @@ extension SendSparkVC {
         fourthButton.identifier = 4
     }
     
-    private func setLayout() {
-        view.addSubviews([firstButton, secondButton, thirdButton, fourthButton])
-        
-        firstButton.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(guideLabel.snp.bottom).offset(20)
-            make.height.equalTo(36)
-            make.width.equalTo(143)
-        }
-        
-        secondButton.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(firstButton.snp.bottom).offset(20)
-            make.height.equalTo(36)
-            make.width.equalTo(157)
-        }
-        
-        thirdButton.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(secondButton.snp.bottom).offset(20)
-            make.height.equalTo(36)
-            make.width.equalTo(120)
-        }
-        
-        fourthButton.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.top.equalTo(thirdButton.snp.bottom).offset(20)
-            make.height.equalTo(36)
-            make.width.equalTo(200)
-        }
-    }
-    
-    // 버튼 타겟 설정
     private func setAddTargets(_ buttons: UIButton...) {
         for button in buttons {
             button.addTarget(self, action: #selector(setSelectedButton(_:)), for: .touchUpInside)
@@ -150,6 +117,42 @@ extension SendSparkVC {
             case .networkFail:
                 print("sendSparkWithAPI - networkFail")
             }
+        }
+    }
+}
+
+// MARK: - Layout
+
+extension SendSparkVC {
+    private func setLayout() {
+        view.addSubviews([firstButton, secondButton, thirdButton, fourthButton])
+        
+        firstButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(guideLabel.snp.bottom).offset(20)
+            make.height.equalTo(36)
+            make.width.equalTo(143)
+        }
+        
+        secondButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(firstButton.snp.bottom).offset(20)
+            make.height.equalTo(36)
+            make.width.equalTo(157)
+        }
+        
+        thirdButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(secondButton.snp.bottom).offset(20)
+            make.height.equalTo(36)
+            make.width.equalTo(120)
+        }
+        
+        fourthButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(thirdButton.snp.bottom).offset(20)
+            make.height.equalTo(36)
+            make.width.equalTo(200)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -15,15 +15,10 @@ class SendSparkVC: UIViewController {
     var recordID: Int?
     var userName: String?
     
-    private var firstButton = SendSparkButton()
-    private var secondButton = SendSparkButton()
-    private var thirdButton = SendSparkButton()
-    private var fourthButton = SendSparkButton()
-    
-    private let firstButtonText: String = "👊 아자아자 파이팅!"
-    private let secondButtonText: String = "🔥오늘 안 해? 같이 해!"
-    private let thirdButtonText: String = "👉 너만 하면 돼!"
-    private let fourthButtonText: String = "👍 얼마 안 남았어, 어서 하자!"
+    private var firstButton = SendSparkButton(type: .first)
+    private var secondButton = SendSparkButton(type: .second)
+    private var thirdButton = SendSparkButton(type: .third)
+    private var fourthButton = SendSparkButton(type: .fourth)
     
     private var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
     
@@ -54,29 +49,11 @@ extension SendSparkVC {
     private func setUI() {
         view.backgroundColor = .sparkBlack.withAlphaComponent(0.8)
         tabBarController?.tabBar.isHidden = true
-        
-        [firstButton, secondButton, thirdButton, fourthButton].forEach {
-            $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
-            $0.layer.cornerRadius = 2
-            $0.layer.borderWidth = 1
-            $0.setTitleColor(.sparkLightPinkred, for: .normal)
-            $0.titleLabel?.font = .krMediumFont(ofSize: 14)
-        }
-        
-        firstButton.setTitle(firstButtonText, for: .normal)
-        secondButton.setTitle(secondButtonText, for: .normal)
-        thirdButton.setTitle(thirdButtonText, for: .normal)
-        fourthButton.setTitle(fourthButtonText, for: .normal)
-        
-        firstButton.identifier = 1
-        secondButton.identifier = 2
-        thirdButton.identifier = 3
-        fourthButton.identifier = 4
     }
     
     private func setAddTargets(_ buttons: UIButton...) {
         for button in buttons {
-            button.addTarget(self, action: #selector(setSelectedButton(_:)), for: .touchUpInside)
+            button.addTarget(self, action: #selector(touchSendSparkButton(_:)), for: .touchUpInside)
         }
     }
     
@@ -88,21 +65,15 @@ extension SendSparkVC {
     // MARK: - @objc Function
     
     @objc
-    func setSelectedButton(_ sender: SendSparkButton) {
+    func touchSendSparkButton(_ sender: SendSparkButton) {
         setFeedbackGenerator()
         
         [firstButton, secondButton, thirdButton, fourthButton].forEach {
-            if $0.identifier != sender.identifier {
-                // 통신실패 시 필요할듯.
-                $0.setTitleColor(.sparkLightPinkred, for: .normal)
-                $0.backgroundColor = .sparkWhite
-                $0.titleLabel?.backgroundColor = .sparkWhite
-                $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
+            if $0.tag == sender.tag {
+                $0.isSelected(true)
             } else {
-                $0.setTitleColor(.sparkDarkPinkred, for: .normal)
-                $0.backgroundColor = .sparkMostLightPinkred
-                $0.titleLabel?.backgroundColor = .sparkMostLightPinkred
-                $0.layer.borderColor = UIColor.sparkDarkPinkred.cgColor
+                // 통신실패 시에도 다시금 deselected 되야하니 필요함.
+                $0.isSelected(false)
             }
         }
         let selectedMessage = sender.titleLabel?.text ?? ""

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -89,9 +89,9 @@ extension SendSparkVC {
     
     @objc
     func setSelectedButton(_ sender: SendSparkButton) {
+        setFeedbackGenerator()
+        
         [firstButton, secondButton, thirdButton, fourthButton].forEach {
-            setFeedbackGenerator()
-            
             if $0.identifier != sender.identifier {
                 $0.setTitleColor(.sparkLightPinkred, for: .normal)
                 $0.backgroundColor = .sparkWhite

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -176,7 +176,7 @@ extension SendSparkVC {
     func sendSparkWithAPI() {
         RoomAPI.shared.sendSpark(roomID: roomID ?? 0, recordID: recordID ?? 0, content: selectedMessage) {  response in
             switch response {
-            case .success(_):
+            case .success:
                 let presentVC = self.presentingViewController
                 self.dismiss(animated: true) {
                     presentVC?.showSparkToast(x: 20, y: 44, message: "\(self.userName ?? "")에게 스파크를 보냈어요!")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -10,14 +10,15 @@ import UIKit
 class SendSparkVC: UIViewController {
 
     // MARK: Properties
-    var selectedMessage: String = ""
+
     var roomID: Int?
     var recordID: Int?
-    var firstButton = StatusButton()
-    var secondButton = StatusButton()
-    var thirdButton = StatusButton()
-    var fourthButton = StatusButton()
     var userName: String?
+    
+    var firstButton = SendSparkButton()
+    var secondButton = SendSparkButton()
+    var thirdButton = SendSparkButton()
+    var fourthButton = SendSparkButton()
     
     // MARK: IBoutlet properties
     
@@ -61,10 +62,10 @@ extension SendSparkVC {
         thirdButton.setTitle("👉 너만 하면 돼!", for: .normal)
         fourthButton.setTitle("👍 얼마 안 남았어, 어서 하자!", for: .normal)
         
-        firstButton.status = 1
-        secondButton.status = 2
-        thirdButton.status = 3
-        fourthButton.status = 4
+        firstButton.identifier = 1
+        secondButton.identifier = 2
+        thirdButton.identifier = 3
+        fourthButton.identifier = 4
     }
     
     private func setLayout() {
@@ -102,79 +103,38 @@ extension SendSparkVC {
     // 버튼 타겟 설정
     private func setAddTargets(_ buttons: UIButton...) {
         for button in buttons {
-            button.addTarget(self, action: #selector(setSelectedButton), for: .touchUpInside)
+            button.addTarget(self, action: #selector(setSelectedButton(_:)), for: .touchUpInside)
         }
     }
     
     // MARK: - @objc Function
     
     @objc
-    func setSelectedButton(sender: StatusButton) {
-        
-        let status = sender.status
-        
-        sender.setTitleColor(.sparkDarkPinkred, for: .normal)
-        sender.backgroundColor = .sparkMostLightPinkred
-        sender.titleLabel?.backgroundColor = .sparkMostLightPinkred
-        sender.layer.borderColor = UIColor.sparkDarkPinkred.cgColor
-        
-        selectedMessage = sender.titleLabel?.text ?? ""
-        
-        switch status {
-        case 1:
-            [firstButton, secondButton, thirdButton, fourthButton].forEach {
-                if $0.status != 1 {
-                    $0.tintColor = .sparkLightPinkred
-                    $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
-                    $0.setTitleColor(.sparkLightPinkred, for: .normal)
-                    $0.backgroundColor = .sparkWhite
-                    $0.titleLabel?.backgroundColor = .sparkWhite
-                }
-            }
-
-        case 2:
-            [firstButton, secondButton, thirdButton, fourthButton].forEach {
-                if $0.status != 2 {
-                    $0.tintColor = .sparkLightPinkred
-                    $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
-                    $0.setTitleColor(.sparkLightPinkred, for: .normal)
-                    $0.backgroundColor = .sparkWhite
-                    $0.titleLabel?.backgroundColor = .sparkWhite
-                }
-            }
-
-        case 3:
-            [firstButton, secondButton, thirdButton, fourthButton].forEach {
-                if $0.status != 3 {
-                    $0.tintColor = .sparkLightPinkred
-                    $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
-                    $0.setTitleColor(.sparkLightPinkred, for: .normal)
-                    $0.backgroundColor = .sparkWhite
-                    $0.titleLabel?.backgroundColor = .sparkWhite
-                }
-            }
-
-        default:
-            [firstButton, secondButton, thirdButton, fourthButton].forEach {
-                if $0.status != 4 {
-                    $0.tintColor = .sparkLightPinkred
-                    $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
-                    $0.setTitleColor(.sparkLightPinkred, for: .normal)
-                    $0.backgroundColor = .sparkWhite
-                    $0.titleLabel?.backgroundColor = .sparkWhite
-                }
+    func setSelectedButton(_ sender: SendSparkButton) {
+        [firstButton, secondButton, thirdButton, fourthButton].forEach {
+            if $0.identifier != sender.identifier {
+                $0.tintColor = .sparkLightPinkred
+                $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
+                $0.setTitleColor(.sparkLightPinkred, for: .normal)
+                $0.backgroundColor = .sparkWhite
+                $0.titleLabel?.backgroundColor = .sparkWhite
+            } else {
+                $0.setTitleColor(.sparkDarkPinkred, for: .normal)
+                $0.backgroundColor = .sparkMostLightPinkred
+                $0.titleLabel?.backgroundColor = .sparkMostLightPinkred
+                $0.layer.borderColor = UIColor.sparkDarkPinkred.cgColor
             }
         }
-        
-        sendSparkWithAPI()
+        let selectedMessage = sender.titleLabel?.text ?? ""
+        sendSparkWithAPI(content: selectedMessage)
     }
 }
 
 // MARK: Network
 
 extension SendSparkVC {
-    func sendSparkWithAPI() {
-        RoomAPI.shared.sendSpark(roomID: roomID ?? 0, recordID: recordID ?? 0, content: selectedMessage) {  response in
+    func sendSparkWithAPI(content: String) {
+        RoomAPI.shared.sendSpark(roomID: roomID ?? 0, recordID: recordID ?? 0, content: content) {  response in
             switch response {
             case .success:
                 let presentVC = self.presentingViewController

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -20,6 +20,11 @@ class SendSparkVC: UIViewController {
     private var thirdButton = SendSparkButton()
     private var fourthButton = SendSparkButton()
     
+    private let firstButtonText: String = "👊 아자아자 파이팅!"
+    private let secondButtonText: String = "🔥오늘 안 해? 같이 해!"
+    private let thirdButtonText: String = "👉 너만 하면 돼!"
+    private let fourthButtonText: String = "👍 얼마 안 남았어, 어서 하자!"
+    
     // MARK: IBoutlet properties
     
     @IBOutlet weak var popUpView: UIView!
@@ -57,10 +62,10 @@ extension SendSparkVC {
             $0.titleLabel?.font = .krMediumFont(ofSize: 14)
         }
         
-        firstButton.setTitle("👊 아자아자 파이팅!", for: .normal)
-        secondButton.setTitle("🔥오늘 안 해? 같이 해!", for: .normal)
-        thirdButton.setTitle("👉 너만 하면 돼!", for: .normal)
-        fourthButton.setTitle("👍 얼마 안 남았어, 어서 하자!", for: .normal)
+        firstButton.setTitle(firstButtonText, for: .normal)
+        secondButton.setTitle(secondButtonText, for: .normal)
+        thirdButton.setTitle(thirdButtonText, for: .normal)
+        fourthButton.setTitle(fourthButtonText, for: .normal)
         
         firstButton.identifier = 1
         secondButton.identifier = 2

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -54,7 +54,6 @@ extension SendSparkVC {
         tabBarController?.tabBar.isHidden = true
         
         [firstButton, secondButton, thirdButton, fourthButton].forEach {
-            $0.tintColor = .sparkLightPinkred
             $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
             $0.layer.cornerRadius = 2
             $0.layer.borderWidth = 1
@@ -85,11 +84,10 @@ extension SendSparkVC {
     func setSelectedButton(_ sender: SendSparkButton) {
         [firstButton, secondButton, thirdButton, fourthButton].forEach {
             if $0.identifier != sender.identifier {
-                $0.tintColor = .sparkLightPinkred
-                $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
                 $0.setTitleColor(.sparkLightPinkred, for: .normal)
                 $0.backgroundColor = .sparkWhite
                 $0.titleLabel?.backgroundColor = .sparkWhite
+                $0.layer.borderColor = UIColor.sparkLightPinkred.cgColor
             } else {
                 $0.setTitleColor(.sparkDarkPinkred, for: .normal)
                 $0.backgroundColor = .sparkMostLightPinkred


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#231

🌱 작업한 내용
- 스파크 보내기 시에 햅틱을 구현하면서 `SendSparkVC` 와 `SendSparkButton` 커스텀 클래스를 리펙토링.
> 참고: https://zeddios.tistory.com/726
> 현재 selection feedback 인데 강도는 추후에 정해보자. 가장 약한 느낌.

### Refactor
> SendSparkVC
- `empty_enum_arguments` swiftLint 따라 리펙토링
- switch 문으로 같은 코드가 반복되는 것을 forEach 구문에서 조건문을 통해서 구현함.
- 해당 선택된 메시지를 저장하고 넘겨줬던 전역변수 selectedMessage 를 없애고 지역변수로 설정해서 스파크 보내기전에는 불필요한 메모리를 차지하지 않도록 함.
- 코드로 오토레이아웃을 잡아주던 부분을 맨 밑으로 이동시켜 가독성을 올림.
- 접근제어자 추가.

> SendSparkButton
- final 키워드를 통해서 상속시키지 않을 클래스임을 밝힘.
> 이점? 여기참조해주세요! : https://velog.io/@ryan-son/Swift-final-키워드-왜-사용하는걸까
- `public init(type: SendSparkStatus)` 를 통해서 오버로딩 개념으로 UI 를 설정.
> 참고: https://ios-development.tistory.com/44
> 참고: https://ios-development.tistory.com/43
- StatusButton 으로 의미전달이 잘되지 않던 부분을 SendSparkButton 클래스를 만들고, 어떤 버튼이 눌렸는지는 tag 를 설정해서 판단할 수 있도록 함. SendSparkButton 클래스에서 액션까지 설정하고 싶었지만 서버통신과 햅틱을 지정해야해서 액션이 두개가 중첩되는 부분 발생. 그래서 `isSelected()` 함수를 통해서 UI 를 바꿔주도록 했다.

## 📮 관련 이슈
- Resolved: #231 
