### PR TITLE
[Fix] #239 - 습관방 로딩 시 셀 초기화 및 구분선 색깔 굵기 및 진하기 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Cells/HabitRoom/HabitRoomMemberCVC.xib
+++ b/Spark-iOS/Spark-iOS/Source/Cells/HabitRoom/HabitRoomMemberCVC.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +20,7 @@
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D9J-Jp-kaz">
                         <rect key="frame" x="20" y="152" width="431" height="1"/>
-                        <color key="backgroundColor" red="0.7803921568627451" green="0.7803921568627451" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" name="sparkLightGray"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="kbG-DU-UYR"/>
                         </constraints>
@@ -101,5 +102,8 @@
     </objects>
     <resources>
         <image name="tagMe" width="43" height="24"/>
+        <namedColor name="sparkLightGray">
+            <color red="0.92900002002716064" green="0.92900002002716064" blue="0.93300002813339233" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -376,7 +376,11 @@ extension HabitRoomVC: UICollectionViewDelegate {
 
 extension HabitRoomVC: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 1 + (habitRoomDetail?.otherRecords.count ?? 0)
+        if let habitRoomDetail = habitRoomDetail {
+            return 1 + (habitRoomDetail.otherRecords.count)
+        } else {
+            return 0
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#239

🌱 작업한 내용
- QA 작업
- 습관방 로딩 시 셀을 0개로 하여 깔끔하게 수정
- 구분선 색깔이 제플린에서 스타일이 적용되어 있지 않아서 임의 지정했는데 정해주져서 QA 보드 보고 변경

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- QA 의 경우 라벨을 하나 만들테니 적용해주세용~

<img width="706" alt="스크린샷 2022-02-09 오후 11 49 33" src="https://user-images.githubusercontent.com/69136340/153225673-9dc2e1f7-451a-4ae1-83f0-56aa403664a7.png">

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|습관방|<img src="https://user-images.githubusercontent.com/69136340/153224590-95e97100-295e-4a1f-9413-ed50fc98f0ef.MP4" width ="250">|

## 📮 관련 이슈
- Resolved: #239
