### PR TITLE
[Fix] #241 - 나의 목표 작성 뷰 디테일 수정 및 extension 분리

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Extensions/UIViewController+.swift
+++ b/Spark-iOS/Spark-iOS/Source/Extensions/UIViewController+.swift
@@ -81,4 +81,30 @@ extension UIViewController {
             }
         }
     }
+    
+    /// textField의 글자수에 따라 countLabel과 lineView의 컬러 및 글자 변경해주는 함수
+    /// - 최대 글자수 초과인 경우
+    /// - 최대 글자수 이하 0 이상인 경우
+    /// - 그 외의 경우 (글자수 0)
+    func changeCountLabel(textField: UITextField, maxLength: Int, countLabel: UILabel, lineView: UIView) {
+        if let text = textField.text {
+            countLabel.text = "\(text.count)/\(maxLength)"
+            
+            if text.count >= maxLength {
+                let maxIndex = text.index(text.startIndex, offsetBy: maxLength)
+                let newString = String(text[text.startIndex..<maxIndex])
+                textField.text = newString
+                countLabel.text = "\(maxLength)/\(maxLength)"
+                countLabel.textColor = .sparkPinkred
+            } else if text.count > 0 {
+                let attributedString = NSMutableAttributedString(string: countLabel.text ?? "")
+                attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.sparkPinkred, range: ((countLabel.text ?? "") as NSString).range(of: "\(text.count)"))
+                countLabel.textColor = .sparkDarkGray
+                countLabel.attributedText = attributedString
+                lineView.backgroundColor = .sparkPinkred
+            } else {
+                countLabel.textColor = .sparkDarkGray
+            }
+        }
+    }
 }

--- a/Spark-iOS/Spark-iOS/Source/Extensions/UIViewController+.swift
+++ b/Spark-iOS/Spark-iOS/Source/Extensions/UIViewController+.swift
@@ -101,7 +101,6 @@ extension UIViewController {
                 attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.sparkPinkred, range: ((countLabel.text ?? "") as NSString).range(of: "\(text.count)"))
                 countLabel.textColor = .sparkDarkGray
                 countLabel.attributedText = attributedString
-                lineView.backgroundColor = .sparkPinkred
             } else {
                 countLabel.textColor = .sparkDarkGray
             }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -140,32 +140,7 @@ class CreateRoomVC: UIViewController {
     @objc
     private func textFieldDidChange(_ notification: Notification) {
         if let textField = notification.object as? UITextField {
-            if let text = textField.text {
-                /// 글자가 바뀔 때마다 countLabel 업데이트
-                countLabel.text = "\(text.count)/15"
-                
-                /// 글자수 count 초과한 경우
-                if text.count >= maxLength {
-                    let maxIndex = text.index(text.startIndex, offsetBy: maxLength)
-                    let newString = String(text[text.startIndex..<maxIndex])
-                    textField.text = newString
-                    countLabel.text = "15/15"
-                    countLabel.textColor = .sparkPinkred
-                }
-                
-                /// 글자 있는 경우 색 활성화, 없는 경우 비활성화
-                else if text.count > 0 {
-                    let attributedString = NSMutableAttributedString(string: countLabel.text ?? "")
-                    attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.sparkPinkred, range: ((countLabel.text ?? "") as NSString).range(of: "\(text.count)"))
-                    countLabel.textColor = .sparkDarkGray
-                    countLabel.attributedText = attributedString
-                }
-                
-                /// 그 외 0인 경우
-                else {
-                    countLabel.textColor = .sparkDarkGray
-                }
-            }
+            changeCountLabel(textField: textField, maxLength: maxLength, countLabel: countLabel, lineView: lineView)
         }
     }
     
@@ -196,7 +171,7 @@ extension CreateRoomVC: UITextFieldDelegate {
     
     /// 입력 시작
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-        ableButton()
+        lineView.backgroundColor = .sparkPinkred
         return true
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -13,15 +13,14 @@ class CreateRoomVC: UIViewController {
     
     // MARK: - Properties
     
-    let closeButton = UIButton()
-    let titleLabel = UILabel()
-    let subTitleLabel = UILabel()
-    let textField = UITextField()
-    let lineView = UIView()
-    let countLabel = UILabel()
-    let nextButton = UIButton()
-    
-    var maxLength: Int = 15
+    private let closeButton = UIButton()
+    private let titleLabel = UILabel()
+    private let subTitleLabel = UILabel()
+    private let textField = UITextField()
+    private let lineView = UIView()
+    private let countLabel = UILabel()
+    private let nextButton = UIButton()
+    private let maxLength: Int = 15
 
     // MARK: - View Life Cycles
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -139,7 +139,7 @@ class CreateRoomVC: UIViewController {
     @objc
     private func textFieldDidChange(_ notification: Notification) {
         if let textField = notification.object as? UITextField {
-            changeCountLabel(textField: textField, maxLength: maxLength, countLabel: countLabel, lineView: lineView)
+            self.changeCountLabel(textField: textField, maxLength: maxLength, countLabel: countLabel, lineView: lineView)
         }
     }
     
@@ -157,24 +157,24 @@ class CreateRoomVC: UIViewController {
 }
 
 extension CreateRoomVC: UITextFieldDelegate {
-    /// 여백 클릭 시
+    // 여백 클릭 시
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
     }
 
-    /// 리턴 눌렀을 때
+    // 리턴 눌렀을 때
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         self.view.endEditing(true)
         return true
     }
     
-    /// 입력 시작
+    // 입력 시작
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         lineView.backgroundColor = .sparkPinkred
         return true
     }
     
-    /// 입력 끝
+    // 입력 끝
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField.hasText {
             ableButton()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -13,22 +13,22 @@ class GoalWritingVC: UIViewController {
     
     // MARK: - Properties
     
-    let closeButton = UIButton()
-    let titleLabel = UILabel()
-    let subTitleLabel = UILabel()
-    let whenLabel = UILabel()
-    let whenExLabel = UILabel()
-    let goalLabel = UILabel()
-    let goalExLabel = UILabel()
-    let whenTextField = UITextField()
-    let whenLineView = UIView()
-    let whenCountLabel = UILabel()
-    let goalTextField = UITextField()
-    let goalLineView = UIView()
-    let goalCountLabel = UILabel()
-    let completeButton = UIButton()
+    private let closeButton = UIButton()
+    private let titleLabel = UILabel()
+    private let subTitleLabel = UILabel()
+    private let whenLabel = UILabel()
+    private let whenExLabel = UILabel()
+    private let goalLabel = UILabel()
+    private let goalExLabel = UILabel()
+    private let whenTextField = UITextField()
+    private let whenLineView = UIView()
+    private let whenCountLabel = UILabel()
+    private let goalTextField = UITextField()
+    private let goalLineView = UIView()
+    private let goalCountLabel = UILabel()
+    private let completeButton = UIButton()
+    private let maxLength: Int = 15
     
-    var maxLength: Int = 15
     var titleText: String?
     var roomId: Int?
     var moment: String?

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -55,7 +55,7 @@ class GoalWritingVC: UIViewController {
         titleLabel.font = .h3Subtitle
         titleLabel.textColor = .sparkBlack
         
-        subTitleLabel.text = "\(titleText ?? "기본") 습관방에서의 \n시간과 목표를 적어 보세요!"
+        subTitleLabel.text = "'\(titleText ?? "기본")' 습관방에서의 \n시간과 목표를 적어 보세요!"
         subTitleLabel.numberOfLines = 2
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -164,71 +164,9 @@ class GoalWritingVC: UIViewController {
         if let textField = notification.object as? UITextField {
             switch textField {
             case whenTextField:
-                if let text = textField.text {
-                    /// 글자가 바뀔 때마다 countLabel 업데이트
-                    whenCountLabel.text = "\(text.count)/15"
-                    
-                    /// 글자수 count 초과한 경우
-                    if text.count >= maxLength {
-                        let maxIndex = text.index(text.startIndex, offsetBy: maxLength)
-                        let newString = String(text[text.startIndex..<maxIndex])
-                        textField.text = newString
-                        whenCountLabel.text = "15/15"
-                        whenCountLabel.textColor = .sparkPinkred
-                    }
-                    
-                    /// 글자 있는 경우 색 활성화, 없는 경우 비활성화
-                    else if text.count > 0 {
-                        let attributedString = NSMutableAttributedString(string: whenCountLabel.text ?? "")
-                        attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.sparkPinkred, range: ((whenCountLabel.text ?? "") as NSString).range(of: "\(text.count)"))
-                        whenCountLabel.textColor = .sparkDarkGray
-                        whenCountLabel.attributedText = attributedString
-                        whenLineView.backgroundColor = .sparkPinkred
-                    }
-                    
-                    else if text.count == 0 {
-                        whenCountLabel.textColor = .sparkDarkGray
-                    }
-                    
-                    /// 그 외 0인 경우
-                    else {
-                        whenCountLabel.textColor = .sparkDarkGray
-                        whenLineView.backgroundColor = .sparkDarkGray
-                    }
-                }
+                changeCountLabel(textField: whenTextField, maxLength: 15, countLabel: whenCountLabel, lineView: whenLineView)
             case goalTextField:
-                if let text = textField.text {
-                    /// 글자가 바뀔 때마다 countLabel 업데이트
-                    goalCountLabel.text = "\(text.count)/15"
-                    
-                    /// 글자수 count 초과한 경우
-                    if text.count >= maxLength {
-                        let maxIndex = text.index(text.startIndex, offsetBy: maxLength)
-                        let newString = String(text[text.startIndex..<maxIndex])
-                        textField.text = newString
-                        goalCountLabel.text = "15/15"
-                        goalCountLabel.textColor = .sparkPinkred
-                    }
-                    
-                    /// 글자 있는 경우 색 활성화, 없는 경우 비활성화
-                    else if text.count > 0 {
-                        let attributedString = NSMutableAttributedString(string: goalCountLabel.text ?? "")
-                        attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.sparkPinkred, range: ((goalCountLabel.text ?? "") as NSString).range(of: "\(text.count)"))
-                        goalCountLabel.textColor = .sparkDarkGray
-                        goalCountLabel.attributedText = attributedString
-                        goalLineView.backgroundColor = .sparkPinkred
-                    }
-                    
-                    else if text.count == 0 {
-                        whenCountLabel.textColor = .sparkDarkGray
-                    }
-                    
-                    /// 그 외 0인 경우
-                    else {
-                        goalCountLabel.textColor = .sparkDarkGray
-                        goalLineView.backgroundColor = .sparkDarkGray
-                    }
-                }
+                changeCountLabel(textField: goalTextField, maxLength: 15, countLabel: goalCountLabel, lineView: goalLineView)
             default:
                 return
             }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -186,6 +186,10 @@ class GoalWritingVC: UIViewController {
                         whenLineView.backgroundColor = .sparkPinkred
                     }
                     
+                    else if text.count == 0 {
+                        whenCountLabel.textColor = .sparkDarkGray
+                    }
+                    
                     /// 그 외 0인 경우
                     else {
                         whenCountLabel.textColor = .sparkDarkGray
@@ -213,6 +217,10 @@ class GoalWritingVC: UIViewController {
                         goalCountLabel.textColor = .sparkDarkGray
                         goalCountLabel.attributedText = attributedString
                         goalLineView.backgroundColor = .sparkPinkred
+                    }
+                    
+                    else if text.count == 0 {
+                        whenCountLabel.textColor = .sparkDarkGray
                     }
                     
                     /// 그 외 0인 경우
@@ -278,6 +286,14 @@ extension GoalWritingVC: UITextFieldDelegate {
     
     /// 입력 시작
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        switch textField {
+        case whenTextField:
+            whenLineView.backgroundColor = .sparkPinkred
+        case goalTextField:
+            goalLineView.backgroundColor = .sparkPinkred
+        default:
+            goalLineView.backgroundColor = .sparkPinkred
+        }
         upAnimation()
         return true
     }
@@ -287,6 +303,12 @@ extension GoalWritingVC: UITextFieldDelegate {
         if whenTextField.hasText && goalTextField.hasText {
             ableButton()
         } else {
+            if !whenTextField.hasText {
+                whenLineView.backgroundColor = .sparkGray
+            }
+            if !goalTextField.hasText {
+                goalLineView.backgroundColor = .sparkGray
+            }
             disableButton()
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -164,9 +164,9 @@ class GoalWritingVC: UIViewController {
         if let textField = notification.object as? UITextField {
             switch textField {
             case whenTextField:
-                changeCountLabel(textField: whenTextField, maxLength: 15, countLabel: whenCountLabel, lineView: whenLineView)
+                self.changeCountLabel(textField: whenTextField, maxLength: 15, countLabel: whenCountLabel, lineView: whenLineView)
             case goalTextField:
-                changeCountLabel(textField: goalTextField, maxLength: 15, countLabel: goalCountLabel, lineView: goalLineView)
+                self.changeCountLabel(textField: goalTextField, maxLength: 15, countLabel: goalCountLabel, lineView: goalLineView)
             default:
                 return
             }
@@ -209,20 +209,20 @@ extension GoalWritingVC {
 
 // MARK: - UITextFieldDelegate
 extension GoalWritingVC: UITextFieldDelegate {
-    /// 여백 클릭 시
+    // 여백 클릭 시
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         downAnimation()
         self.view.endEditing(true)
     }
 
-    /// 리턴 눌렀을 때
+    // 리턴 눌렀을 때
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         downAnimation()
         self.view.endEditing(true)
         return true
     }
     
-    /// 입력 시작
+    // 입력 시작
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         switch textField {
         case whenTextField:
@@ -236,7 +236,7 @@ extension GoalWritingVC: UITextFieldDelegate {
         return true
     }
     
-    /// 입력 끝
+    // 입력 끝
     func textFieldDidEndEditing(_ textField: UITextField) {
         if whenTextField.hasText && goalTextField.hasText {
             ableButton()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -127,7 +127,7 @@ class ProfileSettingVC: UIViewController {
     @objc
     private func textFieldDidChange(_ notification: Notification) {
         if let textField = notification.object as? UITextField {
-            changeCountLabel(textField: textField, maxLength: maxLength, countLabel: countLabel, lineView: lineView)
+            self.changeCountLabel(textField: textField, maxLength: maxLength, countLabel: countLabel, lineView: lineView)
         }
     }
     
@@ -182,24 +182,24 @@ class ProfileSettingVC: UIViewController {
 // MARK: - UITextFieldDelegate
 
 extension ProfileSettingVC: UITextFieldDelegate {
-    /// 여백 클릭 시
+    // 여백 클릭 시
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
     }
     
-    /// 리턴 눌렀을 때
+    // 리턴 눌렀을 때
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         self.view.endEditing(true)
         return true
     }
     
-    /// 입력 시작
+    // 입력 시작
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         lineView.backgroundColor = .sparkPinkred
         return true
     }
     
-    /// 입력 끝
+    // 입력 끝
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField.hasText {
             ableButton()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -25,7 +25,7 @@ class ProfileSettingVC: UIViewController {
     let picker = UIImagePickerController()
     let tap = UITapGestureRecognizer()
     
-    var maxLength: Int = 15
+    var maxLength: Int = 10
     
     // MARK: - View Life Cycle
     
@@ -128,32 +128,7 @@ class ProfileSettingVC: UIViewController {
     @objc
     private func textFieldDidChange(_ notification: Notification) {
         if let textField = notification.object as? UITextField {
-            if let text = textField.text {
-                /// 글자가 바뀔 때마다 countLabel 업데이트
-                countLabel.text = "\(text.count)/15"
-                
-                /// 글자수 count 초과한 경우
-                if text.count >= maxLength {
-                    let maxIndex = text.index(text.startIndex, offsetBy: maxLength)
-                    let newString = String(text[text.startIndex..<maxIndex])
-                    textField.text = newString
-                    countLabel.text = "15/15"
-                    countLabel.textColor = .sparkPinkred
-                }
-                
-                /// 글자 있는 경우 색 활성화, 없는 경우 비활성화
-                else if text.count > 0 {
-                    let attributedString = NSMutableAttributedString(string: countLabel.text ?? "")
-                    attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.sparkPinkred, range: ((countLabel.text ?? "") as NSString).range(of: "\(text.count)"))
-                    countLabel.textColor = .sparkDarkGray
-                    countLabel.attributedText = attributedString
-                }
-                
-                /// 그 외 0인 경우
-                else {
-                    countLabel.textColor = .sparkDarkGray
-                }
-            }
+            changeCountLabel(textField: textField, maxLength: maxLength, countLabel: countLabel, lineView: lineView)
         }
     }
     
@@ -221,7 +196,7 @@ extension ProfileSettingVC: UITextFieldDelegate {
     
     /// 입력 시작
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-        ableButton()
+        lineView.backgroundColor = .sparkPinkred
         return true
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -13,19 +13,18 @@ class ProfileSettingVC: UIViewController {
     
     // MARK: - Properties
     
-    let closeButton = UIButton()
-    let titleLabel = UILabel()
-    let profileImageView = UIImageView()
-    let fadeView = UIView()
-    let photoIconImageView = UIImageView()
-    let textField = UITextField()
-    let lineView = UIView()
-    let countLabel = UILabel()
-    let completeButton = UIButton()
-    let picker = UIImagePickerController()
-    let tap = UITapGestureRecognizer()
-    
-    var maxLength: Int = 10
+    private let closeButton = UIButton()
+    private let titleLabel = UILabel()
+    private let profileImageView = UIImageView()
+    private let fadeView = UIView()
+    private let photoIconImageView = UIImageView()
+    private let textField = UITextField()
+    private let lineView = UIView()
+    private let countLabel = UILabel()
+    private let completeButton = UIButton()
+    private let picker = UIImagePickerController()
+    private let tap = UITapGestureRecognizer()
+    private let maxLength: Int = 10
     
     // MARK: - View Life Cycle
     


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#241

🌱 작업한 내용
- 상단의 멘트 중 '습관방' 작은 따옴표 추가
- 텍스트필드 선택시 라인 컬러 변경
- 텍스트필드, count, line 관련 함수 `changeCountLabel` UIViewController+ 에 분리 
- GoalWritingVC, CreateRoomVC, ProfileSettingVC 위의 함수 추가
- 접근제한자 추가

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
일단 QA 반영했습니다.
그리구 텍스트필드 관련 공통되는 부분을 묶고자 했는데, 엄.... 조금 1이 커질 것 같아서 일단은 
텍스트필드에 따라 countLabel과 lineView가 변경되는 부분만 UIViewController+에 분리했습니다.
그리고 같은 식으로 텍스트필드가 쓰이는 VC에 모두 적용해줬습니다.
건들인 김에 접근제한자도 추가했습니다. 예..

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 나의 목표작성 뷰 | 생략..  |

## 📮 관련 이슈
- Resolved: #241 
