### PR TITLE
[Fix] #244 - 대기방 뷰 디테일 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -255,7 +255,7 @@ extension WaitingVC {
                        completion: nil)
         
         UIView.animate(withDuration: 0.6,
-                       delay: 0.1,
+                       delay: 0.0,
                        options: .curveEaseInOut,
                        animations: {
             let rotate = CGAffineTransform(rotationAngle: -(3.14*2.0))

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -246,11 +246,20 @@ extension WaitingVC {
     }
     
     private func refreshButtonAnimtation() {
-        UIView.animate(withDuration: 0.4,
-                       delay: 0.1,
+        UIView.animate(withDuration: 0.6,
+                       delay: 0.0,
                        options: .curveEaseInOut,
                        animations: {
             let rotate = CGAffineTransform(rotationAngle: -3.14)
+            self.refreshButton.transform = rotate
+        },
+                       completion: nil)
+        
+        UIView.animate(withDuration: 0.6,
+                       delay: 0.1,
+                       options: .curveEaseInOut,
+                       animations: {
+            let rotate = CGAffineTransform(rotationAngle: -(3.14*2.0))
             self.refreshButton.transform = rotate
         },
                        completion: { _ in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -546,14 +546,14 @@ extension WaitingVC {
         
         copyButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(6)
             make.width.equalTo(87)
             make.height.equalTo(36)
         }
         
         checkTitleLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview().inset(20)
-            make.top.equalTo(copyButton.snp.bottom).offset(UIScreen.main.hasNotch ? 36 : 20)
+            make.top.equalTo(copyButton.snp.bottom).offset(UIScreen.main.hasNotch ? 40 : 24)
         }
         
         toolTipButton.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -140,8 +140,8 @@ extension WaitingVC {
         NotificationCenter.default.post(name: .disappearFloatingButton, object: nil)
         
         profileImageView.backgroundColor = .sparkLightGray
-        firstDivideView.backgroundColor = .sparkDarkGray.withAlphaComponent(0.5)
-        secondDivideView.backgroundColor = .sparkDarkGray.withAlphaComponent(0.5)
+        firstDivideView.backgroundColor = .sparkLightGray
+        secondDivideView.backgroundColor = .sparkLightGray
         checkDivideView.backgroundColor = .sparkDarkGray
         
         toolTipImageView.layer.masksToBounds = true
@@ -587,7 +587,7 @@ extension WaitingVC {
         firstDivideView.snp.makeConstraints { make in
             make.top.equalTo(checkTitleLabel.snp.bottom).offset(UIScreen.main.hasNotch ? 36 : 24)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(0.5)
+            make.height.equalTo(1)
         }
         
         goalTitleLabel.snp.makeConstraints { make in
@@ -627,7 +627,7 @@ extension WaitingVC {
         secondDivideView.snp.makeConstraints { make in
             make.top.equalTo(goalLabel.snp.bottom).offset(UIScreen.main.hasNotch ? 45 : 30)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(0.5)
+            make.height.equalTo(1)
         }
         
         friendTitleLabel.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -197,7 +197,7 @@ extension WaitingVC {
         startButton.isHidden = true
     }
     
-    // 선택한 인증 방식에 따라 라벨을 보이는 함수
+    /// 선택한 인증 방식에 따라 라벨을 보이는 함수
     private func setAuthLabel() {
         if photoOnly ?? true {
             [stopwatchLabel, checkDivideView].forEach { $0.isHidden = true }
@@ -245,24 +245,22 @@ extension WaitingVC {
     }
     
     private func refreshButtonAnimtation() {
-        UIView.animate(withDuration: 0.6,
-                       delay: 0.0,
-                       options: .curveEaseInOut,
+        UIView.animate(withDuration: 0.3,
+                       delay: 0,
+                       options: .curveEaseIn,
                        animations: {
-            let rotate = CGAffineTransform(rotationAngle: -3.14)
-            self.refreshButton.transform = rotate
-        },
-                       completion: nil)
-        
-        UIView.animate(withDuration: 0.6,
-                       delay: 0.0,
-                       options: .curveEaseInOut,
-                       animations: {
-            let rotate = CGAffineTransform(rotationAngle: -(3.14*2.0))
-            self.refreshButton.transform = rotate
-        },
-                       completion: { _ in
-            self.refreshButton.transform = .identity
+            let firstRotate = CGAffineTransform(rotationAngle: -3.14)
+            self.refreshButton.transform = firstRotate
+        }, completion: { _ in
+            UIView.animate(withDuration: 0.3,
+                           delay: 0.0,
+                           options: .curveEaseOut,
+                           animations: {
+                let secondRotate = CGAffineTransform(rotationAngle: -(3.14*2.0))
+                self.refreshButton.transform = secondRotate
+            }, completion: { _ in
+                self.refreshButton.transform = .identity
+            })
         })
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -59,7 +59,7 @@ class WaitingVC: UIViewController {
     private var members: [Member] = []
     private var memberList: [Any] = []
     
-    var photoOnly: Bool? // 사진 인증만
+    var photoOnly: Bool?
     var roomName: String?
     var roomCode: String?
     var roomId: Int?
@@ -85,7 +85,6 @@ class WaitingVC: UIViewController {
         super.viewWillAppear(animated)
         
         DispatchQueue.main.async {
-            // 로딩
             self.setLoading()
         }
         
@@ -198,7 +197,7 @@ extension WaitingVC {
         startButton.isHidden = true
     }
     
-    /// 선택한 인증 방식
+    // 선택한 인증 방식에 따라 라벨을 보이는 함수
     private func setAuthLabel() {
         if photoOnly ?? true {
             [stopwatchLabel, checkDivideView].forEach { $0.isHidden = true }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#244

🌱 작업한 내용
- [x] 습관방 이름 - 코드복사 사이 간격 조정
- [x] 구분선 굵기 색깔 진하게
- [x] 새로고침 모션 후 위치 요상한 문제 해결

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
새로고침 모션 후 위치가 요상한 문제는 일단 아예 360도를 돌려서 해결했습니다
기존 코드는 에셋 자체를 180도 회전시키고 원래대로 돌려놓는 애니메이션이고, 원래대로 돌려놔야 또 다시 회전이 가능해서 일단은 
아예 360도 냅다 회전시켰슴니다
```
    private func refreshButtonAnimtation() {
        UIView.animate(withDuration: 0.6,
                       delay: 0.0,
                       options: .curveEaseInOut,
                       animations: {
            let rotate = CGAffineTransform(rotationAngle: -3.14)
            self.refreshButton.transform = rotate
        },
                       completion: nil)
        
        UIView.animate(withDuration: 0.6,
                       delay: 0.1,
                       options: .curveEaseInOut,
                       animations: {
            let rotate = CGAffineTransform(rotationAngle: -(3.14*2.0))
            self.refreshButton.transform = rotate
        },
                       completion: { _ in
            self.refreshButton.transform = .identity
        })
    }
```
- 양수를 사용하면 오른쪽으로 반바퀴 회전을 하는데, 저희는 왼쪽으로 회전해야되기 때문에 음수를 붙였습니다.
- 또 애니메이션을 한 번 써서 한번에 `3.14*2.0` 만큼 앵글을 돌릴 수 있을 줄 알았는데, 안되더라구요..
그래서 왜일까 조금 찾아보니, 저 애니메이션의 의미가 회전을 시켜서 `3.14*2.0`의 위치로 가도록 만들겠다는건데 그럼 이미 그 위치에 있는 것이기 때문에 회전하지 않았습니다.. 
그래서 애니메이션을 두 번 사용해서 먼저 180도(3.14)의 위치까지 회전해서 간 다음에 180도의 위치에서 360도 위치만큼 회전해서 가겠다! 는 식으로 코드를 짰습니다..
말하다보니 그냥 completion에 연속적으로 하는 것이 더 나을랑가 모르겠네요 이것도 한번 해봐야겠당

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 대기방방방 | ![ezgif com-gif-maker (47)](https://user-images.githubusercontent.com/81167570/153356146-d700dda3-59ac-433a-9470-4fcbea5b43b9.gif)  |

## 📮 관련 이슈
- Resolved: #244 
