### PR TITLE
[Fix] #250 - 피드 footer 마지막 멘트가 중간에 보이는 문제 해결

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedFooterView.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Feed/FeedFooterView.swift
@@ -21,6 +21,7 @@ class FeedFooterView: UICollectionReusableView {
         super.init(frame: frame)
         setUI()
         setLayout()
+        playLoading()
     }
     
     required init?(coder: NSCoder) {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -320,7 +320,7 @@ extension FeedVC: UICollectionViewDataSource {
                 guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: Const.Cell.Identifier.feedFooterView, for: indexPath) as? FeedFooterView else { return UICollectionReusableView() }
                 
                 // 마지막 스크롤이면 loading 멈추고, 마지막이 아닌 경우 loading
-                if isLastScroll {
+                if isLastScroll && isInfiniteScroll {
                     footer.stopLoading()
                 } else {
                     footer.playLoading()


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#250

🌱 작업한 내용
- 피드뷰 마지막 멘트가 중간에 보이는 문제 해결
기존 코드를 보면 `viewForSupplementaryElementOfKind` 에서 isLastScroll에 따라 footer의 상태를 정해줬습니다.
근데 요 부분에 중간중간 로딩이 떠야하는 부분에 마지막 멘트가 뜨는 문제가 발생했습니다.
```
print("🙇‍♀️ indexPath: \(indexPath), isLastScroll: \(isLastScroll), isInfinitiScroll: \(isInfiniteScroll)")
```

그래서 프린트를 찍어보니, 
```
🙇‍♀️ indexPath: [0, 0], isLastScroll: false, isInfinitiScroll: true -> 로딩
🙇‍♀️ indexPath: [1, 0], isLastScroll: false, isInfinitiScroll: true
🙇‍♀️ indexPath: [1, 0], isLastScroll: true, isInfinitiScroll: false -> 마지막 멘트
🙇‍♀️ indexPath: [2, 0], isLastScroll: false, isInfinitiScroll: true
🙇‍♀️ indexPath: [2, 0], isLastScroll: false, isInfinitiScroll: true
🙇‍♀️ indexPath: [3, 0], isLastScroll: false, isInfinitiScroll: true
🙇‍♀️ indexPath: [3, 0], isLastScroll: true, isInfinitiScroll: false

...

**🙇‍♀️ indexPath: [6, 0], isLastScroll: true, isInfinitiScroll: true** -> 진짜 마지막 멘트
```
요런식으로 찍혔습니다.
보아하니 마지막 스크롤에 도달해서 get을 해왔는데 해당 섹션의 데이터가 더이상 없는 경우? 이 섹션이 마지막 섹션이라고 인식을 하면서 isLastScroll이 true,isinfiniteScroll이 false이 되는 것 같더라구요!
진정한 마지막 섹션에 도달했을 때는 isLastScroll과 isInfiniteScroll이 true인 경우이기 때문에 조건을 추가했슴다


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
놉 .. 


## 📮 관련 이슈
- Resolved: #250 
