### PR TITLE
[Add] #252 - 플로팅버튼 라이브러리 재설치

### DIFF
--- a/Spark-iOS/Podfile
+++ b/Spark-iOS/Podfile
@@ -10,7 +10,7 @@ target 'Spark-iOS' do
   pod 'Kingfisher', '~> 7.0'
   pod 'SwiftLint'
   pod 'Moya', '~> 15.0'
-  pod 'JJFloatingActionButton'
+  pod 'JJFloatingActionButton', :git => 'https://github.com/TeamSparker/JJFloatingActionButton.git', :branch => 'spark'
   pod 'KakaoSDKCommon'
   pod 'KakaoSDKUser'
   pod 'KakaoSDKAuth'

--- a/Spark-iOS/Podfile.lock
+++ b/Spark-iOS/Podfile.lock
@@ -124,7 +124,7 @@ PODS:
 DEPENDENCIES:
   - Firebase/Analytics
   - Firebase/Messaging
-  - JJFloatingActionButton
+  - JJFloatingActionButton (from `https://github.com/TeamSparker/JJFloatingActionButton.git`, branch `spark`)
   - KakaoSDKAuth
   - KakaoSDKCommon
   - KakaoSDKUser
@@ -146,7 +146,6 @@ SPEC REPOS:
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
-    - JJFloatingActionButton
     - KakaoSDKAuth
     - KakaoSDKCommon
     - KakaoSDKUser
@@ -157,6 +156,16 @@ SPEC REPOS:
     - PromisesObjC
     - SnapKit
     - SwiftLint
+
+EXTERNAL SOURCES:
+  JJFloatingActionButton:
+    :branch: spark
+    :git: https://github.com/TeamSparker/JJFloatingActionButton.git
+
+CHECKOUT OPTIONS:
+  JJFloatingActionButton:
+    :commit: fe37182f3c13c2800a530e8a965654536f6a1632
+    :git: https://github.com/TeamSparker/JJFloatingActionButton.git
 
 SPEC CHECKSUMS:
   Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
@@ -181,6 +190,6 @@ SPEC CHECKSUMS:
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
 
-PODFILE CHECKSUM: f04cc734671a9cb5a7f7c0cc78e3a646005c1e64
+PODFILE CHECKSUM: cb90bf3724e3427764b629df69e79cb75d9ce25c
 
 COCOAPODS: 1.11.2

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
@@ -98,6 +98,7 @@ extension MainTBC {
         // 아이템 버튼 컬러 변경. defualt 는 white 임.
         floatingButton.configureDefaultItem { item in
             item.buttonColor = .sparkDarkPinkred
+            item.layer.shadowColor = .none
         }
     }
     


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#252

🌱 작업한 내용
- 수정한 pod을 설치했슴다
- 쉐도우 삭제했슴다

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 홈 플로팅버튼 | <img src="https://user-images.githubusercontent.com/81167570/153707299-13295b1d-3a9d-4c1c-93be-be7073b7d3fa.PNG" width="40%" /> |

## 📮 관련 이슈
- Resolved: #252 
