### PR TITLE
[Fix] #281 - 나의 목표 작성 뷰 두번째 텍스트필드 활성화 안되는 문제 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -238,15 +238,28 @@ extension GoalWritingVC: UITextFieldDelegate {
     
     // 입력 끝
     func textFieldDidEndEditing(_ textField: UITextField) {
+        // 텍스트필드에 따라 lineView 색상 각각 처리
+        switch textField {
+        case whenTextField:
+            if whenTextField.hasText {
+                whenLineView.backgroundColor = .sparkPinkred
+            } else {
+                whenLineView.backgroundColor = .sparkGray
+            }
+        case goalTextField:
+            if goalTextField.hasText {
+                goalLineView.backgroundColor = .sparkPinkred
+            } else {
+                goalLineView.backgroundColor = .sparkGray
+            }
+        default:
+            return
+        }
+        
+        // 하단 버튼 색상 처리
         if whenTextField.hasText && goalTextField.hasText {
             ableButton()
         } else {
-            if !whenTextField.hasText {
-                whenLineView.backgroundColor = .sparkGray
-            }
-            if !goalTextField.hasText {
-                goalLineView.backgroundColor = .sparkGray
-            }
             disableButton()
         }
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#281

🌱 작업한 내용
- 나의 목표 작성 뷰 두번째 텍스트필드 활성화가 안되는 문제 수정

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 텍스트필드 입력이 끝났을때 하단 버튼과 lineView 색상 변경하는 부분을 분리했습니다.
- 가장 효율적인 코드인지는 모르겠습니다..

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 텍스트필드 |  ![ezgif com-gif-maker (50)](https://user-images.githubusercontent.com/81167570/154705536-d454768b-8266-4d5d-ad52-1c1c138ae72b.gif)  |

## 📮 관련 이슈
- Resolved: #281 
