### PR TITLE
[Refactor] #275 - BottomButton 컴포넌트 분리

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2B014FAF27AAA90E004B4559 /* FeedFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B014FAE27AAA90E004B4559 /* FeedFooterView.swift */; };
+		2B0CF77427BFEDAC003C2E21 /* BottomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0CF77327BFEDAC003C2E21 /* BottomButton.swift */; };
 		2B13FB23279899C6004CCE46 /* UIScreen+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B13FB22279899C6004CCE46 /* UIScreen+.swift */; };
 		2B13FB252798B705004CCE46 /* CompleteAuthVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C50892792A86D00588155 /* CompleteAuthVC.swift */; };
 		2B13FB262798B70A004CCE46 /* MyRoomCerti.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE90FCD2795C23A00157075 /* MyRoomCerti.swift */; };
@@ -152,6 +153,7 @@
 
 /* Begin PBXFileReference section */
 		2B014FAE27AAA90E004B4559 /* FeedFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedFooterView.swift; sourceTree = "<group>"; };
+		2B0CF77327BFEDAC003C2E21 /* BottomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButton.swift; sourceTree = "<group>"; };
 		2B13FB22279899C6004CCE46 /* UIScreen+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+.swift"; sourceTree = "<group>"; };
 		2B57F37B27968A28002A677D /* CreateRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoom.swift; sourceTree = "<group>"; };
 		2B57F37D27969791002A677D /* RoomId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomId.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 				EBE90FDD2796C45900157075 /* StatusButton.swift */,
 				F86C68B627955ABA009A5296 /* SparkFlake.swift */,
 				F8404E8A27AB835F004AEDC3 /* SendSparkButton.swift */,
+				2B0CF77327BFEDAC003C2E21 /* BottomButton.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1214,6 +1217,7 @@
 				EB625E7F278F272300C43DE9 /* DoneStorageCVC.swift in Sources */,
 				EBEA382D27947C9100B5736A /* MyRoomAPI.swift in Sources */,
 				2B69E7E7278E28B2000F927F /* FeedCVC.swift in Sources */,
+				2B0CF77427BFEDAC003C2E21 /* BottomButton.swift in Sources */,
 				2BE5D80827930A06007A544D /* AuthTimerVC.swift in Sources */,
 				EBEA38372794B34300B5736A /* CodeJoinCheck.swift in Sources */,
 				F8096F2B27841F4100B71D38 /* Storyboard.swift in Sources */,

--- a/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
@@ -26,10 +26,6 @@ class BottomButton: UIButton {
     
     // MARK: - Method
     
-    func setBottomButtonTitle(title: String) {
-        setTitle(title, for: .normal)
-    }
-    
     private func setUI() {
         backgroundColor = .sparkDarkPinkred
         titleLabel?.font = .enBoldFont(ofSize: 18)
@@ -38,7 +34,22 @@ class BottomButton: UIButton {
     
     private func setLayout() {
         self.snp.makeConstraints { make in
-            make.height.equalTo(UIScreen.main.bounds.width * 48 / 335)
+            make.width.equalTo(UIScreen.main.bounds.width - 40)
+            make.height.equalTo((UIScreen.main.bounds.width - 40) * 48 / 335)
         }
+    }
+    
+    func setBottomButtonTitle(title: String) {
+        setTitle(title, for: .normal)
+    }
+    
+    func setAbleBottomButton() {
+        self.backgroundColor = .sparkDarkPinkred
+        self.isEnabled = true
+    }
+    
+    func setDisableBottomButton() {
+        self.backgroundColor = .sparkGray
+        self.isEnabled = false
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
@@ -19,7 +19,6 @@ class BottomButton: UIButton {
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-//        fatalError("init(coder:) has not been implemented")
         setUI()
         setLayout()
     }
@@ -39,17 +38,23 @@ class BottomButton: UIButton {
         }
     }
     
-    func setBottomButtonTitle(title: String) {
-        setTitle(title, for: .normal)
+    @discardableResult
+    func setTitle(_ title: String) -> Self {
+        self.setTitle(title, for: .normal)
+        return self
     }
     
-    func setAbleBottomButton() {
+    @discardableResult
+    func setAble() -> Self {
         self.backgroundColor = .sparkDarkPinkred
         self.isEnabled = true
+        return self
     }
     
-    func setDisableBottomButton() {
+    @discardableResult
+    func setDisable() -> Self {
         self.backgroundColor = .sparkGray
         self.isEnabled = false
+        return self
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
@@ -26,7 +26,7 @@ class BottomButton: UIButton {
         setLayout()
     }
     
-    // MARK: - Custom Method
+    // MARK: - Method
     
     private func setUI(title: String) {
         backgroundColor = .sparkPinkred

--- a/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
@@ -13,23 +13,17 @@ class BottomButton: UIButton {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setLayout()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public init(title: String) {
-        super.init(frame: .zero)
-        
-        setUI(title: title)
-        setLayout()
-    }
-    
     // MARK: - Method
     
-    private func setUI(title: String) {
-        backgroundColor = .sparkPinkred
+    func setUI(title: String) {
+        backgroundColor = .sparkDarkPinkred
         setTitle(title, for: .normal)
         titleLabel?.font = .enBoldFont(ofSize: 18)
         layer.cornerRadius = 2

--- a/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
@@ -13,18 +13,25 @@ class BottomButton: UIButton {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        setUI()
         setLayout()
     }
     
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
+//        fatalError("init(coder:) has not been implemented")
+        setUI()
+        setLayout()
     }
     
     // MARK: - Method
     
-    func setUI(title: String) {
-        backgroundColor = .sparkDarkPinkred
+    func setBottomButtonTitle(title: String) {
         setTitle(title, for: .normal)
+    }
+    
+    private func setUI() {
+        backgroundColor = .sparkDarkPinkred
         titleLabel?.font = .enBoldFont(ofSize: 18)
         layer.cornerRadius = 2
     }
@@ -33,9 +40,5 @@ class BottomButton: UIButton {
         self.snp.makeConstraints { make in
             make.height.equalTo(UIScreen.main.bounds.width * 48 / 335)
         }
-    }
-    
-    func changeButtonTitle(title: String) {
-        setTitle(title, for: .normal)
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
@@ -1,0 +1,47 @@
+//
+//  BottomButton.swift
+//  Spark-iOS
+//
+//  Created by 양수빈 on 2022/02/19.
+//
+
+import UIKit
+
+class BottomButton: UIButton {
+
+    // MARK: - Initialize
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public init(title: String) {
+        super.init(frame: .zero)
+        
+        setUI(title: title)
+        setLayout()
+    }
+    
+    // MARK: - Custom Method
+    
+    private func setUI(title: String) {
+        backgroundColor = .sparkPinkred
+        setTitle(title, for: .normal)
+        titleLabel?.font = .enBoldFont(ofSize: 18)
+        layer.cornerRadius = 2
+    }
+    
+    private func setLayout() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(UIScreen.main.bounds.width * 48 / 335)
+        }
+    }
+    
+    func changeButtonTitle(title: String) {
+        setTitle(title, for: .normal)
+    }
+}

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -13,18 +13,18 @@ class AuthTimerVC: UIViewController {
     
     // MARK: - Properties
     
-    let titleLabel = UILabel()
-    let firstLabel = UILabel()
-    let secondLabel = UILabel()
-    let stopwatchLabel = UILabel()
-    let photoLabel = UILabel()
-    let betweenLine = UIView()
-    let divideLine = UIView()
-    let timeLabel = UILabel()
-    let bottomButton = UIButton()
-    let pauseButton = UIButton()
-    let resetButton = UIButton()
-    let closeButton = UIButton()
+    private let titleLabel = UILabel()
+    private let firstLabel = UILabel()
+    private let secondLabel = UILabel()
+    private let stopwatchLabel = UILabel()
+    private let photoLabel = UILabel()
+    private let betweenLine = UIView()
+    private let divideLine = UIView()
+    private let timeLabel = UILabel()
+    private let bottomButton = BottomButton(title: "시간 측정 시작")
+    private let pauseButton = UIButton()
+    private let resetButton = UIButton()
+    private let closeButton = UIButton()
     
     var isTimerOn: Bool = false
     var currentTimeCount: Int = 0
@@ -84,9 +84,6 @@ class AuthTimerVC: UIViewController {
         secondLabel.textColor = .sparkGray
         stopwatchLabel.textColor = .sparkPinkred
         photoLabel.textColor = .sparkGray
-        
-        bottomButton.layer.cornerRadius = 2
-        bottomButton.titleLabel?.font = .enBoldFont(ofSize: 18)
         
         closeButton.setImage(UIImage(named: "icQuit"), for: .normal)
         pauseButton.setImage(UIImage(named: "btnStop"), for: .normal)
@@ -278,8 +275,6 @@ extension AuthTimerVC {
         bottomButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-            make.width.equalToSuperview().inset(20)
-            make.height.equalTo(self.view.frame.width*48/335)
         }
         
         resetButton.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -21,7 +21,7 @@ class AuthTimerVC: UIViewController {
     private let betweenLine = UIView()
     private let divideLine = UIView()
     private let timeLabel = UILabel()
-    private let bottomButton = BottomButton(title: "시간 측정 시작")
+    private let bottomButton = BottomButton()
     private let pauseButton = UIButton()
     private let resetButton = UIButton()
     private let closeButton = UIButton()
@@ -107,6 +107,8 @@ class AuthTimerVC: UIViewController {
         button.setTitle(title, for: UIControl.State())
         button.isEnabled = isEnable
         button.backgroundColor = backgroundColor
+        button.titleLabel?.font = .enBoldFont(ofSize: 18)
+        button.layer.cornerRadius = 2
     }
     
     // MARK: - @objc
@@ -190,7 +192,7 @@ class AuthTimerVC: UIViewController {
     func resetTimer(_ sender: AnyObject) {
         currentTimeCount = 0
         timeLabel.text = "00:00:00"
-        setButton(bottomButton, title: "시간 측정 시작", backgroundColor: .sparkDarkPinkred, isEnable: true)
+        setButton(bottomButton, title: "시작하기", backgroundColor: .sparkDarkPinkred, isEnable: true)
         pauseButton.setImage(UIImage(named: "btnStop"), for: .normal)
         [pauseButton, resetButton].forEach { $0.isHidden = true }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -21,27 +21,27 @@ class AuthUploadVC: UIViewController {
     
     // MARK: - Properties
     
-    let closeButton = UIButton()
-    let titleLabel = UILabel()
+    private let closeButton = UIButton()
+    private let titleLabel = UILabel()
+    private let fadeImageView = UIImageView()
+    private let firstLabel = UILabel()
+    private let secondLabel = UILabel()
+    private let stopwatchLabel = UILabel()
+    private let photoLabel = UILabel()
+    private let betweenLine = UIView()
+    private let photoAuthButton = BottomButton(title: "사진 인증하기")
+    private let picker = UIImagePickerController()
+    private var buttonStackView = UIStackView()
+    private var uploadButton = UIButton()
+    private var changePhotoButton = UIButton()
     var uploadImageView = UIImageView()
-    let fadeImageView = UIImageView()
-    var buttonStackView = UIStackView()
-    var uploadButton = UIButton()
-    var changePhotoButton = UIButton()
     var timerLabel = UILabel()
-    let firstLabel = UILabel()
-    let secondLabel = UILabel()
-    let stopwatchLabel = UILabel()
-    let photoLabel = UILabel()
-    let betweenLine = UIView()
-    let photoAuthButton = UIButton()
-    let picker = UIImagePickerController()
     var roomId: Int?
     var roomName: String?
     var vcType: VCCase?
     
-    lazy var loadingBgView = UIView()
-    lazy var loadingView = AnimationView(name: Const.Lottie.Name.loading)
+    private lazy var loadingBgView = UIView()
+    private lazy var loadingView = AnimationView(name: Const.Lottie.Name.loading)
     
     // MARK: - Life Cycle
     
@@ -106,11 +106,6 @@ extension AuthUploadVC {
         
         betweenLine.backgroundColor = .sparkPinkred
         
-        photoAuthButton.layer.cornerRadius = 2
-        photoAuthButton.titleLabel?.font = .enBoldFont(ofSize: 18)
-        photoAuthButton.setTitle("사진 인증하기", for: .normal)
-        photoAuthButton.backgroundColor = .sparkDarkPinkred
-        
         fadeImageView.backgroundColor = .sparkBlack.withAlphaComponent(0.15)
         uploadImageView.contentMode = .scaleAspectFill
         uploadImageView.layer.masksToBounds = true
@@ -134,7 +129,7 @@ extension AuthUploadVC {
         uploadButton.layer.cornerRadius = 2
         uploadButton.titleLabel?.font = .btn1Default
         uploadButton.setTitle("업로드하기", for: .normal)
-        uploadButton.backgroundColor = .sparkDarkPinkred
+        uploadButton.backgroundColor = .sparkPinkred
         uploadButton.isEnabled = true
         
         switch vcType {
@@ -377,7 +372,6 @@ extension AuthUploadVC {
         photoAuthButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-            make.height.equalTo(self.view.frame.width*48/335)
         }
         
         uploadImageView.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -29,7 +29,7 @@ class AuthUploadVC: UIViewController {
     private let stopwatchLabel = UILabel()
     private let photoLabel = UILabel()
     private let betweenLine = UIView()
-    private let photoAuthButton = BottomButton()
+    private let photoAuthButton = BottomButton().setTitle("사진 인증하기")
     private let picker = UIImagePickerController()
     private var buttonStackView = UIStackView()
     private var uploadButton = UIButton()
@@ -131,8 +131,6 @@ extension AuthUploadVC {
         uploadButton.setTitle("업로드하기", for: .normal)
         uploadButton.backgroundColor = .sparkDarkPinkred
         uploadButton.isEnabled = true
-        
-        photoAuthButton.setBottomButtonTitle(title: "사진 인증하기")
         
         switch vcType {
         case .photoOnly:

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -132,7 +132,7 @@ extension AuthUploadVC {
         uploadButton.backgroundColor = .sparkDarkPinkred
         uploadButton.isEnabled = true
         
-        photoAuthButton.setUI(title: "사진 인증하기")
+        photoAuthButton.setBottomButtonTitle(title: "사진 인증하기")
         
         switch vcType {
         case .photoOnly:

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -29,7 +29,7 @@ class AuthUploadVC: UIViewController {
     private let stopwatchLabel = UILabel()
     private let photoLabel = UILabel()
     private let betweenLine = UIView()
-    private let photoAuthButton = BottomButton(title: "사진 인증하기")
+    private let photoAuthButton = BottomButton()
     private let picker = UIImagePickerController()
     private var buttonStackView = UIStackView()
     private var uploadButton = UIButton()
@@ -129,8 +129,10 @@ extension AuthUploadVC {
         uploadButton.layer.cornerRadius = 2
         uploadButton.titleLabel?.font = .btn1Default
         uploadButton.setTitle("업로드하기", for: .normal)
-        uploadButton.backgroundColor = .sparkPinkred
+        uploadButton.backgroundColor = .sparkDarkPinkred
         uploadButton.isEnabled = true
+        
+        photoAuthButton.setUI(title: "사진 인증하기")
         
         switch vcType {
         case .photoOnly:
@@ -200,15 +202,15 @@ extension AuthUploadVC {
     }
     
     private func openLibrary() {
-        /// UIImagePickerController에서 어떤 식으로 image를 pick해올지 -> 앨범에서 픽해오겠다
+        // UIImagePickerController에서 어떤 식으로 image를 pick해올지 -> 앨범에서 픽해오겠다
         picker.sourceType = .photoLibrary
         present(picker, animated: false, completion: nil)
     }
     
     private func openCamera() {
-        /// 카메라 촬영 타입이 가능하다면
+        // 카메라 촬영 타입이 가능하다면
         if UIImagePickerController.isSourceTypeAvailable(.camera) {
-            /// UIImagePickerController에서 어떤 식으로 image를 pick해올지 -> 카메라 촬영헤서 픽해오겠다
+            // UIImagePickerController에서 어떤 식으로 image를 pick해올지 -> 카메라 촬영헤서 픽해오겠다
             picker.sourceType = .camera
             present(picker, animated: false, completion: nil)
         } else {
@@ -220,7 +222,7 @@ extension AuthUploadVC {
         let alter = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alter.view.tintColor = .sparkBlack
         
-        /// alter에 들어갈 액션 생성
+        // alter에 들어갈 액션 생성
         let library = UIAlertAction(title: "카메라 촬영", style: .default) { _ in
             self.openCamera()
         }
@@ -229,12 +231,12 @@ extension AuthUploadVC {
         }
         let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         
-        /// alter에 액션을 넣어줌
+        // alter에 액션을 넣어줌
         alter.addAction(library)
         alter.addAction(camera)
         alter.addAction(cancel)
         
-        /// button tap했을 때 alter present
+        // button tap했을 때 alter present
         present(alter, animated: true, completion: nil)
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -18,7 +18,7 @@ class CreateAuthVC: UIViewController {
     private let subTitleLabel = UILabel()
     private let photoAuthView = PhotoAuthView()
     private let timerAuthView = TimerAuthView()
-    private let enterButton = BottomButton()
+    private let enterButton = BottomButton().setTitle("대기방 입장하기")
     
     /// photoOnly가 true이면 fromStart가 false
     var photoOnly: Bool = true
@@ -56,8 +56,6 @@ class CreateAuthVC: UIViewController {
         subTitleLabel.numberOfLines = 2
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray
-        
-        enterButton.setBottomButtonTitle(title: "대기방 입장하기")
         
         photoAuthView.setSelectedUI()
         timerAuthView.setDeselectedUI()
@@ -169,7 +167,7 @@ extension CreateAuthVC {
         }
         
         enterButton.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(20)
+            make.centerX.equalToSuperview()
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -18,7 +18,7 @@ class CreateAuthVC: UIViewController {
     private let subTitleLabel = UILabel()
     private let photoAuthView = PhotoAuthView()
     private let timerAuthView = TimerAuthView()
-    private let enterButton = BottomButton(title: "대기방 입장하기")
+    private let enterButton = BottomButton()
     
     /// photoOnly가 true이면 fromStart가 false
     var photoOnly: Bool = true
@@ -56,6 +56,8 @@ class CreateAuthVC: UIViewController {
         subTitleLabel.numberOfLines = 2
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray
+        
+        enterButton.setUI(title: "대기방 입장하기")
         
         photoAuthView.setSelectedUI()
         timerAuthView.setDeselectedUI()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -14,11 +14,12 @@ class CreateAuthVC: UIViewController {
     
     // MARK: - Properties
     
-    let titleLabel = UILabel()
-    let subTitleLabel = UILabel()
-    let photoAuthView = PhotoAuthView()
-    let timerAuthView = TimerAuthView()
-    let enterButton = UIButton()
+    private let titleLabel = UILabel()
+    private let subTitleLabel = UILabel()
+    private let photoAuthView = PhotoAuthView()
+    private let timerAuthView = TimerAuthView()
+    private let enterButton = BottomButton(title: "대기방 입장하기")
+    
     /// photoOnly가 true이면 fromStart가 false
     var photoOnly: Bool = true
     var roomName: String = ""
@@ -55,11 +56,6 @@ class CreateAuthVC: UIViewController {
         subTitleLabel.numberOfLines = 2
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray
-        
-        enterButton.layer.cornerRadius = 2
-        enterButton.titleLabel?.font = .enBoldFont(ofSize: 18)
-        enterButton.setTitle("대기방 입장하기", for: .normal)
-        enterButton.backgroundColor = .sparkPinkred
         
         photoAuthView.setSelectedUI()
         timerAuthView.setDeselectedUI()
@@ -173,8 +169,6 @@ extension CreateAuthVC {
         enterButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-            make.width.equalToSuperview().inset(20)
-            make.height.equalTo(self.view.frame.width*48/335)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -57,7 +57,7 @@ class CreateAuthVC: UIViewController {
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray
         
-        enterButton.setUI(title: "대기방 입장하기")
+        enterButton.setBottomButtonTitle(title: "대기방 입장하기")
         
         photoAuthView.setSelectedUI()
         timerAuthView.setDeselectedUI()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -19,7 +19,7 @@ class CreateRoomVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private let nextButton = UIButton()
+    private let nextButton = BottomButton(title: "다음으로")
     private let maxLength: Int = 15
 
     // MARK: - View Life Cycles
@@ -51,9 +51,6 @@ class CreateRoomVC: UIViewController {
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray
         
-        nextButton.layer.cornerRadius = 2
-        nextButton.titleLabel?.font = .enBoldFont(ofSize: 18)
-        nextButton.setTitle("다음으로", for: .normal)
         nextButton.backgroundColor = .sparkGray
         nextButton.isEnabled = false
         
@@ -181,8 +178,6 @@ extension CreateRoomVC {
         nextButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-            make.width.equalToSuperview().inset(20)
-            make.height.equalTo(self.view.frame.width*48/335)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -52,15 +52,13 @@ class CreateRoomVC: UIViewController {
         subTitleLabel.textColor = .sparkDarkGray
         
         nextButton.setBottomButtonTitle(title: "다음으로")
-        nextButton.backgroundColor = .sparkGray
-        nextButton.isEnabled = false
+        nextButton.setDisableBottomButton()
+        lineView.backgroundColor = .sparkGray
         
         textField.borderStyle = .none
         textField.placeholder = "ex. 30분 독서"
         textField.delegate = self
         textField.tintColor = .sparkPinkred
-
-        lineView.backgroundColor = .sparkGray
 
         countLabel.text = "0/15"
         countLabel.font = .p2SubtitleEng
@@ -76,17 +74,7 @@ class CreateRoomVC: UIViewController {
         closeButton.addTarget(self, action: #selector(touchCloseButton), for: .touchUpInside)
     }
     
-    private func ableButton() {
-        lineView.backgroundColor = .sparkPinkred
-        nextButton.backgroundColor = .sparkDarkPinkred
-        nextButton.isEnabled = true
-    }
-    
-    private func disableButton() {
-        lineView.backgroundColor = .sparkGray
-        nextButton.backgroundColor = .sparkGray
-        nextButton.isEnabled = false
-    }
+    // MARK: - @objc
     
     @objc
     private func textFieldDidChange(_ notification: Notification) {
@@ -129,9 +117,11 @@ extension CreateRoomVC: UITextFieldDelegate {
     // 입력 끝
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField.hasText {
-            ableButton()
+            nextButton.setAbleBottomButton()
+            lineView.backgroundColor = .sparkPinkred
         } else {
-            disableButton()
+            nextButton.setDisableBottomButton()
+            lineView.backgroundColor = .sparkGray
         }
     }
 }
@@ -177,7 +167,7 @@ extension CreateRoomVC {
         }
         
         nextButton.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(20)
+            make.centerX.equalTo(view.safeAreaLayoutGuide)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -19,7 +19,7 @@ class CreateRoomVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private let nextButton = BottomButton()
+    private let nextButton = BottomButton().setTitle("다음으로").setDisable()
     private let maxLength: Int = 15
 
     // MARK: - View Life Cycles
@@ -51,8 +51,6 @@ class CreateRoomVC: UIViewController {
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray
         
-        nextButton.setBottomButtonTitle(title: "다음으로")
-        nextButton.setDisableBottomButton()
         lineView.backgroundColor = .sparkGray
         
         textField.borderStyle = .none
@@ -117,10 +115,10 @@ extension CreateRoomVC: UITextFieldDelegate {
     // 입력 끝
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField.hasText {
-            nextButton.setAbleBottomButton()
+            nextButton.setAble()
             lineView.backgroundColor = .sparkPinkred
         } else {
-            nextButton.setDisableBottomButton()
+            nextButton.setDisable()
             lineView.backgroundColor = .sparkGray
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -51,7 +51,7 @@ class CreateRoomVC: UIViewController {
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray
         
-        nextButton.setUI(title: "다음으로")
+        nextButton.setBottomButtonTitle(title: "다음으로")
         nextButton.backgroundColor = .sparkGray
         nextButton.isEnabled = false
         
@@ -78,7 +78,7 @@ class CreateRoomVC: UIViewController {
     
     private func ableButton() {
         lineView.backgroundColor = .sparkPinkred
-        nextButton.backgroundColor = .sparkPinkred
+        nextButton.backgroundColor = .sparkDarkPinkred
         nextButton.isEnabled = true
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -19,7 +19,7 @@ class CreateRoomVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private let nextButton = BottomButton(title: "다음으로")
+    private let nextButton = BottomButton()
     private let maxLength: Int = 15
 
     // MARK: - View Life Cycles
@@ -51,6 +51,7 @@ class CreateRoomVC: UIViewController {
         subTitleLabel.font = .krRegularFont(ofSize: 18)
         subTitleLabel.textColor = .sparkDarkGray
         
+        nextButton.setUI(title: "다음으로")
         nextButton.backgroundColor = .sparkGray
         nextButton.isEnabled = false
         

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -26,7 +26,7 @@ class GoalWritingVC: UIViewController {
     private let goalTextField = UITextField()
     private let goalLineView = UIView()
     private let goalCountLabel = UILabel()
-    private let completeButton = UIButton()
+    private let completeButton = BottomButton(title: "작성 완료")
     private let maxLength: Int = 15
     
     var titleText: String?
@@ -76,9 +76,6 @@ class GoalWritingVC: UIViewController {
         goalExLabel.font = .p2Subtitle
         goalExLabel.textColor = .sparkDarkGray
         
-        completeButton.layer.cornerRadius = 2
-        completeButton.titleLabel?.font = .enBoldFont(ofSize: 18)
-        completeButton.setTitle("작성 완료", for: .normal)
         completeButton.backgroundColor = .sparkGray
         completeButton.isEnabled = false
         
@@ -336,8 +333,6 @@ extension GoalWritingVC {
         completeButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-            make.width.equalToSuperview().inset(20)
-            make.height.equalTo(self.view.frame.width*48/335)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -77,8 +77,7 @@ class GoalWritingVC: UIViewController {
         goalExLabel.textColor = .sparkDarkGray
         
         completeButton.setBottomButtonTitle(title: "작성 완료")
-        completeButton.backgroundColor = .sparkGray
-        completeButton.isEnabled = false
+        completeButton.setDisableBottomButton()
         
         whenTextField.text = "\(moment ?? "")"
         whenTextField.borderStyle = .none
@@ -106,16 +105,6 @@ class GoalWritingVC: UIViewController {
     private func setAddTarget() {
         completeButton.addTarget(self, action: #selector(touchCompleteButton), for: .touchUpInside)
         closeButton.addTarget(self, action: #selector(touchCloseButton), for: .touchUpInside)
-    }
-    
-    private func ableButton() {
-        completeButton.backgroundColor = .sparkPinkred
-        completeButton.isEnabled = true
-    }
-
-    private func disableButton() {
-        completeButton.backgroundColor = .sparkGray
-        completeButton.isEnabled = false
     }
     
     private func upAnimation() {
@@ -153,7 +142,7 @@ class GoalWritingVC: UIViewController {
             countLabel.attributedText = attributedString
             lineView.backgroundColor = .sparkPinkred
             
-            ableButton()
+            completeButton.setAbleBottomButton()
         }
     }
     
@@ -256,9 +245,9 @@ extension GoalWritingVC: UITextFieldDelegate {
         
         // 하단 버튼 색상 처리
         if whenTextField.hasText && goalTextField.hasText {
-            ableButton()
+            completeButton.setAbleBottomButton()
         } else {
-            disableButton()
+            completeButton.setDisableBottomButton()
         }
     }
 }
@@ -345,7 +334,7 @@ extension GoalWritingVC {
         }
         
         completeButton.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(20)
+            make.centerX.equalTo(view.safeAreaLayoutGuide)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -26,7 +26,7 @@ class GoalWritingVC: UIViewController {
     private let goalTextField = UITextField()
     private let goalLineView = UIView()
     private let goalCountLabel = UILabel()
-    private let completeButton = BottomButton()
+    private let completeButton = BottomButton().setTitle("작성 완료").setDisable()
     private let maxLength: Int = 15
     
     var titleText: String?
@@ -75,9 +75,6 @@ class GoalWritingVC: UIViewController {
         goalExLabel.text = "ex. 포기하지 말자 / 하루에 1페이지씩"
         goalExLabel.font = .p2Subtitle
         goalExLabel.textColor = .sparkDarkGray
-        
-        completeButton.setBottomButtonTitle(title: "작성 완료")
-        completeButton.setDisableBottomButton()
         
         whenTextField.text = "\(moment ?? "")"
         whenTextField.borderStyle = .none
@@ -142,7 +139,7 @@ class GoalWritingVC: UIViewController {
             countLabel.attributedText = attributedString
             lineView.backgroundColor = .sparkPinkred
             
-            completeButton.setAbleBottomButton()
+            completeButton.setAble()
         }
     }
     
@@ -245,9 +242,9 @@ extension GoalWritingVC: UITextFieldDelegate {
         
         // 하단 버튼 색상 처리
         if whenTextField.hasText && goalTextField.hasText {
-            completeButton.setAbleBottomButton()
+            completeButton.setAble()
         } else {
-            completeButton.setDisableBottomButton()
+            completeButton.setDisable()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -76,7 +76,7 @@ class GoalWritingVC: UIViewController {
         goalExLabel.font = .p2Subtitle
         goalExLabel.textColor = .sparkDarkGray
         
-        completeButton.setUI(title: "작성 완료")
+        completeButton.setBottomButtonTitle(title: "작성 완료")
         completeButton.backgroundColor = .sparkGray
         completeButton.isEnabled = false
         

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -26,7 +26,7 @@ class GoalWritingVC: UIViewController {
     private let goalTextField = UITextField()
     private let goalLineView = UIView()
     private let goalCountLabel = UILabel()
-    private let completeButton = BottomButton(title: "작성 완료")
+    private let completeButton = BottomButton()
     private let maxLength: Int = 15
     
     var titleText: String?
@@ -76,6 +76,7 @@ class GoalWritingVC: UIViewController {
         goalExLabel.font = .p2Subtitle
         goalExLabel.textColor = .sparkDarkGray
         
+        completeButton.setUI(title: "작성 완료")
         completeButton.backgroundColor = .sparkGray
         completeButton.isEnabled = false
         

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -21,7 +21,7 @@ class ProfileSettingVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private let completeButton = UIButton()
+    private let completeButton = BottomButton(title: "가입완료")
     private let picker = UIImagePickerController()
     private let tap = UITapGestureRecognizer()
     private let maxLength: Int = 10
@@ -68,9 +68,6 @@ class ProfileSettingVC: UIViewController {
         countLabel.font = .p2SubtitleEng
         countLabel.textColor = .sparkDarkGray
         
-        completeButton.layer.cornerRadius = 2
-        completeButton.titleLabel?.font = .enBoldFont(ofSize: 18)
-        completeButton.setTitle("가입완료", for: .normal)
         completeButton.backgroundColor = .sparkGray
         completeButton.isEnabled = false
     }
@@ -275,8 +272,6 @@ extension ProfileSettingVC {
         completeButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-            make.width.equalToSuperview().inset(20)
-            make.height.equalTo(self.view.frame.width*48/335)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -88,18 +88,6 @@ class ProfileSettingVC: UIViewController {
         tap.addTarget(self, action: #selector(showAlter))
     }
     
-    private func ableButton() {
-        lineView.backgroundColor = .sparkPinkred
-        completeButton.backgroundColor = .sparkPinkred
-        completeButton.isEnabled = true
-    }
-    
-    private func disableButton() {
-        lineView.backgroundColor = .sparkGray
-        completeButton.backgroundColor = .sparkGray
-        completeButton.isEnabled = false
-    }
-    
     private func openLibrary() {
         picker.sourceType = .photoLibrary
         present(picker, animated: false, completion: nil)
@@ -200,9 +188,11 @@ extension ProfileSettingVC: UITextFieldDelegate {
     // 입력 끝
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField.hasText {
-            ableButton()
+            completeButton.setAbleBottomButton()
+            lineView.backgroundColor = .sparkPinkred
         } else {
-            disableButton()
+            completeButton.setDisableBottomButton()
+            lineView.backgroundColor = .sparkGray
         }
     }
 }
@@ -271,7 +261,7 @@ extension ProfileSettingVC {
         }
         
         completeButton.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(20)
+            make.centerX.equalTo(view.safeAreaLayoutGuide)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -21,7 +21,7 @@ class ProfileSettingVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private let completeButton = BottomButton()
+    private var completeButton = BottomButton().setTitle("가입완료").setDisable()
     private let picker = UIImagePickerController()
     private let tap = UITapGestureRecognizer()
     private let maxLength: Int = 10
@@ -67,10 +67,6 @@ class ProfileSettingVC: UIViewController {
         countLabel.text = "0/15"
         countLabel.font = .p2SubtitleEng
         countLabel.textColor = .sparkDarkGray
-        
-        completeButton.setBottomButtonTitle(title: "가입완료")
-        completeButton.backgroundColor = .sparkGray
-        completeButton.isEnabled = false
     }
     
     private func setDelegate() {
@@ -188,10 +184,10 @@ extension ProfileSettingVC: UITextFieldDelegate {
     // 입력 끝
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField.hasText {
-            completeButton.setAbleBottomButton()
+            completeButton.setAble()
             lineView.backgroundColor = .sparkPinkred
         } else {
-            completeButton.setDisableBottomButton()
+            completeButton.setDisable()
             lineView.backgroundColor = .sparkGray
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -68,7 +68,7 @@ class ProfileSettingVC: UIViewController {
         countLabel.font = .p2SubtitleEng
         countLabel.textColor = .sparkDarkGray
         
-        completeButton.setUI(title: "가입완료")
+        completeButton.setBottomButtonTitle(title: "가입완료")
         completeButton.backgroundColor = .sparkGray
         completeButton.isEnabled = false
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -21,7 +21,7 @@ class ProfileSettingVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private let completeButton = BottomButton(title: "가입완료")
+    private let completeButton = BottomButton()
     private let picker = UIImagePickerController()
     private let tap = UITapGestureRecognizer()
     private let maxLength: Int = 10
@@ -68,6 +68,7 @@ class ProfileSettingVC: UIViewController {
         countLabel.font = .p2SubtitleEng
         countLabel.textColor = .sparkDarkGray
         
+        completeButton.setUI(title: "가입완료")
         completeButton.backgroundColor = .sparkGray
         completeButton.isEnabled = false
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -181,7 +181,7 @@ extension WaitingVC {
         }
         friendSubTitleLabel.textColor = .gray
         
-        startButton.setUI(title: "습관방 만들기")
+        startButton.setBottomButtonTitle(title: "습관방 만들기")
         startButton.isHidden = true
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -47,7 +47,7 @@ class WaitingVC: UIViewController {
     private let friendCountLabel = UILabel()
     private let friendSubTitleLabel = UILabel()
     private let refreshButton = UIButton()
-    private let startButton = UIButton()
+    private let startButton = BottomButton(title: "습관방 만들기")
     
     private let tapGestrueRecognizer = UITapGestureRecognizer()
     private let collectionViewFlowLayout = UICollectionViewFlowLayout()
@@ -181,10 +181,6 @@ extension WaitingVC {
         }
         friendSubTitleLabel.textColor = .gray
         
-        startButton.layer.cornerRadius = 2
-        startButton.titleLabel?.font = .enBoldFont(ofSize: 18)
-        startButton.setTitle("습관방 만들기", for: .normal)
-        startButton.backgroundColor = .sparkPinkred
         startButton.isHidden = true
     }
     
@@ -660,8 +656,6 @@ extension WaitingVC {
         startButton.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-            make.width.equalToSuperview().inset(20)
-            make.height.equalTo(self.view.frame.width * 48 / 335)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -47,7 +47,7 @@ class WaitingVC: UIViewController {
     private let friendCountLabel = UILabel()
     private let friendSubTitleLabel = UILabel()
     private let refreshButton = UIButton()
-    private let startButton = BottomButton(title: "습관방 만들기")
+    private let startButton = BottomButton()
     
     private let tapGestrueRecognizer = UITapGestureRecognizer()
     private let collectionViewFlowLayout = UICollectionViewFlowLayout()
@@ -181,6 +181,7 @@ extension WaitingVC {
         }
         friendSubTitleLabel.textColor = .gray
         
+        startButton.setUI(title: "습관방 만들기")
         startButton.isHidden = true
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -47,7 +47,7 @@ class WaitingVC: UIViewController {
     private let friendCountLabel = UILabel()
     private let friendSubTitleLabel = UILabel()
     private let refreshButton = UIButton()
-    private let startButton = BottomButton()
+    private let startButton = BottomButton().setTitle("습관방 만들기")
     
     private let tapGestrueRecognizer = UITapGestureRecognizer()
     private let collectionViewFlowLayout = UICollectionViewFlowLayout()
@@ -181,7 +181,6 @@ extension WaitingVC {
         }
         friendSubTitleLabel.textColor = .gray
         
-        startButton.setBottomButtonTitle(title: "습관방 만들기")
         startButton.isHidden = true
     }
     
@@ -655,7 +654,7 @@ extension WaitingVC {
         }
         
         startButton.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(20)
+            make.centerX.equalToSuperview()
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }
     }


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#275

🌱 작업한 내용
- [x] BottomButton.swift 파일 생성
- [x] 프로필 설정, 대기방, 나의 목표 작성, 타이머 인증, 사진 인증, 방 이름 생성, 방 인증방식 선택 뷰 적용
- [x] 접근제한자 추가
- [x] 스토리보드에서 사용할 수 있도록 추가 및 확인

**_🚨이 풀리퀘는 일단 제가 좀 더 해보구 마무리 한 뒤, 
한번 더 태그를 해드리든지해서 다시 한번 언급해드리겠슴니다! 그때 확인해주셔두 좋아요!
문제를 만나서 작업 마무리가 조굼 늦어지는데 진행상황정도는 공유하는 것이 좋을것 같아서 일단 냅다 올리고 봅니다.._**

스토리보드에서도 사용하기 위해 타이틀을 설정하는 함수는 `setBottomButtonTitle()` 함수를 따로 분리했습니다.
#### ✔️ 코드베이스로 사용할 경우
```
// 버튼 생성
let bottomButton = BottomButton()

// 버튼 타이틀 입력
bottomButton.setBottomButtonTitle(title: "제목입니다")

// 버튼 레이아웃
view.addSubView(bottom)
bottomButton.snp.makConstraints {
    // height와 width는 BottomButton에서 적용하기 때문에 상하좌우으로 위치를 잡아주시면 됩니다
}
```

#### ❓ 스토리보드에서 사용할 경우
button 객체를 생성해준 뒤, class에 BottomButton을 지정해줍니다
그리구 setUI와 같은 부분에 아래 코드로 타이틀만 넣어주면 되는 것으루 생각했는데 . . .
+) 레이아웃은 하단과 좌우만 잡아주시면 됩니다!
```
.setBottomButtonTitle(titile: "제목임둥")
```
현재 스토리보드 상에서 적용을 해보려구 하니까 일단은 위 코드에서 `Thread 1: EXC_BAD_ACCESS (code=2, address=0x1dadd5de0)` 이 에러가 떠서 지굼 알아보는 중입니다.. 
혹시나 뭔가 .. 제가 놓친 부분이 보이신다면 언급 부탁드리구,, 저두 좀만 더 해보고 말씀드리겠슴니다.

<br>

**🚨0220 3:00 업데이트 삐용**
1️⃣ BottomButton에 아래 함수를 추가했습니다.
추가된 부분은 CreateRoomVC, GoalWritingVC, ProfileSettingVC 의 ableButton, disableButton 함수를 취합한거구, 적용했슴니다!
```
func setAbleBottomButton() {
        self.backgroundColor = .sparkDarkPinkred
        self.isEnabled = true
}
    
func setDisableBottomButton() {
        self.backgroundColor = .sparkGray
        self.isEnabled = false
}
```
2️⃣ 그리구 BottomButton 레이아웃을 수정했습니다.
기존에는 height만 잡아주고, VC에서 leading, trailing, bottom을 잡아줬었는데 width도 추가했습니다.
현규선배가 말해준 것 처럼 self.frame.width를 기준으로 잡아보니까 self.frame.width가 0으로 잡혀서 적용되지 않더라구요.. 코드베이스에서는 안되는건가..
그리구 제가 잘못 생각했던게 전에는 VC에서 바로 레이아웃을 잡았어서 view.frame.width로 하는게 됐는데, 지금 컴포넌트로 분리를 하니까 UIScreen의 width 자체로 따지면 안되는거드라구여
그래서 어 BottomButton의 width는 항상 UIScreen 으로부터 양쪽 20씩 벌어진 것이기 때문에..? 일단 녜 아래와 같이 잡았습니다.
```
private func setLayout() {
        self.snp.makeConstraints { make in
            make.width.equalTo(UIScreen.main.bounds.width - 40)
            make.height.equalTo((UIScreen.main.bounds.width - 40) * 48 / 335)
        }
}
```
그래서 이제는 VC에서 레이아웃을 잡을때는 centerX와 bottom 만 잡아주시면 됩니당


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
다시보니 타이머 부분 코드가 BottomButton 컴포넌트를 만드는게 의미가 있나 싶을정도로 굉장히 더럽네요 
추후에 리팩토링할 시간이 된다면 해보겠습니다
시간이 된다면..



## 📮 관련 이슈
- Resolved: #275 
