### PR TITLE
[Design] #290 - 대기방 토스트메세지 위치 수정, 하단 버튼 타이틀 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -387,7 +387,7 @@ extension AuthUploadVC {
         buttonStackView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-            make.height.equalTo(self.view.frame.width*48/335)
+            make.height.equalTo((UIScreen.main.bounds.width - 40 ) * 48 / 335)
         }
         
         changePhotoButton.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -47,7 +47,7 @@ class WaitingVC: UIViewController {
     private let friendCountLabel = UILabel()
     private let friendSubTitleLabel = UILabel()
     private let refreshButton = UIButton()
-    private let startButton = BottomButton().setTitle("습관방 만들기")
+    private let startButton = BottomButton().setTitle("습관 시작하기")
     
     private let tapGestrueRecognizer = UITapGestureRecognizer()
     private let collectionViewFlowLayout = UICollectionViewFlowLayout()
@@ -343,7 +343,7 @@ extension WaitingVC {
     @objc
     private func copyToClipboard() {
         UIPasteboard.general.string = roomCode
-        showToast(x: 20, y: startButton.frame.minY - 60, message: "코드를 복사했어요", font: .p1TitleLight)
+        showToast(x: 20, y: view.safeAreaInsets.top, message: "코드를 복사했어요!", font: .p1TitleLight)
     }
     
     @objc


### PR DESCRIPTION
## 🌴 PR 요약

🌱 작업한 브랜치
- feature/#290

🌱 작업한 내용
- 대기방 토스트메세지 위치 수정
- 대기방 하단 버튼 타이틀 수정
- 사진인증뷰 하단 스택버튼 높이 수정


## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
뷰를 보니까 토스트메세지가 상태바 아래 바로 붙어있더라구여
지금은 대기방에서 코드복사를 하면 시스템 네비바를 사용하고 있기 때문에 네비바의 아래 붙지만
수정될 네비바는 uiview이기 때문에 상관없이 safeArea 기준으로 바로 상단에 붙여두면 되겠다 생각하고 수정했습니다
나중에 네비바가 수정된 후 자연스레 위로 올라가리라 생각합니다..


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|파일첨부바람|

## 📮 관련 이슈
- Resolved: #290 #293 
