### PR TITLE
[Feat] #307 - 고민중 선택시 고민중 비활성화

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/HabitRoom/HabitAuth.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/HabitRoom/HabitAuth.storyboard
@@ -94,10 +94,11 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N1k-GB-OYv">
-                                                <rect key="frame" x="45.333333333333329" y="28.333333333333371" width="60.333333333333329" height="31"/>
+                                                <rect key="frame" x="44" y="28.333333333333371" width="63" height="34"/>
                                                 <color key="tintColor" name="sparkBrightPinkred"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="고민중"/>
+                                                <inset key="contentEdgeInsets" minX="12" minY="8" maxX="12" maxY="8"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="고민중"/>
                                             </button>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -142,10 +143,11 @@
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BNv-lW-fXW">
-                                        <rect key="frame" x="251.33333333333334" y="366.66666666666669" width="60.333333333333343" height="31"/>
+                                        <rect key="frame" x="250" y="366.66666666666669" width="63" height="34"/>
                                         <color key="tintColor" name="sparkBrightPinkred"/>
-                                        <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="쉴래요"/>
+                                        <inset key="contentEdgeInsets" minX="12" minY="8" maxX="12" maxY="8"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="쉴래요"/>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
@@ -8,7 +8,8 @@
 import UIKit
 import AVFoundation
 
-@frozen enum AuthType {
+@frozen
+enum AuthType {
     case photoOnly
     case photoTimer
 }
@@ -23,6 +24,14 @@ class HabitAuthVC: UIViewController {
     var roomName: String?
     var presentAlertClosure: (() -> Void)?
     var restStatus: String?
+    
+    @frozen
+    private enum Status: String {
+        case none = "NONE"
+        case consider = "CONSIDER"
+        case done = "DONE"
+        case rest = "REST"
+    }
     
     // MARK: - @IBOutlet Properties
     
@@ -68,36 +77,48 @@ extension HabitAuthVC {
         okButton.titleLabel?.text = "지금 습관 인증하기"
         okButton.tintColor = .sparkGray
         
-        if restStatus == "REST" {
-            okButton.isEnabled = false
-            okButton.layer.borderColor = UIColor.sparkGray.cgColor
-            okButton.backgroundColor = .sparkWhite
-            okButton.setTitleColor(.sparkGray, for: .normal)
-            okButton.setTitleColor(.sparkGray, for: .disabled)
-        } else {
+        guard let restStatus = restStatus, let status = Status(rawValue: restStatus) else { return }
+        switch status {
+        case .none:
             okButton.isEnabled = true
             okButton.setTitleColor(.sparkWhite, for: .normal)
             okButton.layer.borderColor = UIColor.sparkDarkPinkred.cgColor
             okButton.backgroundColor = .sparkDarkPinkred
+            
+            considerButton.isEnabled = true
+            considerButton.setTitleColor(.sparkLightPinkred, for: .highlighted)
+            considerButton.layer.borderColor = UIColor.sparkLightPinkred.cgColor
+        case .consider:
+            okButton.isEnabled = true
+            okButton.setTitleColor(.sparkWhite, for: .normal)
+            okButton.layer.borderColor = UIColor.sparkDarkPinkred.cgColor
+            okButton.backgroundColor = .sparkDarkPinkred
+            
+            considerButton.isEnabled = false
+            considerButton.layer.borderColor = UIColor.sparkGray.cgColor
+            considerButton.setTitleColor(.sparkGray, for: .disabled)
+        case .rest:
+            return
+        case .done:
+            return
         }
-
-        considerButton.setTitleColor(.sparkLightPinkred, for: .highlighted)
-        considerButton.layer.borderColor = UIColor.sparkLightPinkred.cgColor
+        
         considerButton.layer.borderWidth = 1
         considerButton.layer.cornerRadius = 2
         
-        restButton.setTitleColor(.sparkLightPinkred, for: .highlighted)
-        restButton.layer.borderColor = UIColor.sparkLightPinkred.cgColor
         restButton.layer.borderWidth = 1
         restButton.layer.cornerRadius = 2
         
         restNumberLabel.text = String(restNumber ?? 0)
         
-        if (restNumber == 0) || (restStatus == "REST") {
+        if restNumber == 0 {
             restButton.isEnabled = false
             restButton.layer.borderColor = UIColor.sparkGray.cgColor
-            restButton.setTitleColor(.sparkGray, for: .normal)
-            restButton.tintColor = .sparkGray
+            restButton.setTitleColor(.sparkGray, for: .disabled)
+        } else {
+            restButton.isEnabled = true
+            restButton.setTitleColor(.sparkLightPinkred, for: .highlighted)
+            restButton.layer.borderColor = UIColor.sparkLightPinkred.cgColor
         }
     }
     


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#307

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 문자열이 아닌 Status 열거형으로 처리.
- 고민중일때 고민중 버튼 비활성화.
- 쉴래요(REST)와 인증완료(DONE) 시에는 HabitAuthVC 가 열리지 않기때문에 아무런 설정도 해주지 않음.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 버튼 스타일이 plain 이어서 tinitcolor 를 통해서 색을 설정해주어야했다. 그래서 고민중, 쉴래요 버튼 스타일 default 로 변경해서 setTitleColor 가 적용되도록 함.(중복된 구현에 대한 코드 삭제)
- 이로인해 button 에 테두리가 딱붙게되어서 스토리보드에서 contentInsets 로 상하좌우 설정.
<img src="https://user-images.githubusercontent.com/69136340/155495674-0d3c41cc-f7d0-4610-932d-a6cd5b62c0c3.png" width ="500">

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/69136340/155495663-d45a0eca-b415-4cc9-9875-ed0ae3bc8f7d.jpeg" width ="250">|

## 📟 관련 이슈
- Resolved: #이슈번호
