### PR TITLE
[Feat] #314 - 쉴래요 다이얼로그 추가

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Dialogue/Dialogue.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
@@ -15,6 +15,7 @@ enum DialogueType {
     case exitAuth
     case resetTimer
     case exitTimer
+    case rest
 }
 
 class DialogueVC: UIViewController {
@@ -80,6 +81,13 @@ extension DialogueVC {
             이미 측정한 시간 기록이 사라집니다.
             그래도 나가시겠습니까?
             """
+            
+        case .rest:
+            guideLabel.text = """
+            ‘쉴래요’를 사용하면 오늘의 인증은
+            건너뛰게 되고, 방 생명은 유지됩니다.
+            """
+            resetOrExitLabel.text = "사용하기"
             
         case .none:
             print("dialogueType을 지정해주세요")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
@@ -107,7 +107,7 @@ extension DialogueVC {
     
     @objc
     private func cancelAction() {
-        self.dismiss(animated: false, completion: nil)
+        self.dismiss(animated: true, completion: nil)
     }
     
     /// 나가기 또는 초기화 액션을 넣어주세요

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
@@ -160,23 +160,23 @@ extension HabitAuthVC {
     @objc
     private func touchConsiderButton() {
         setConsiderRestWithAPI(statusType: "CONSIDER")
-        dismiss(animated: true, completion: nil)
     }
     
     @objc
     private func touchRestButton() {
-        okButton.isEnabled = false
-        okButton.layer.borderColor = UIColor.sparkGray.cgColor
-        okButton.setTitleColor(.sparkGray, for: .normal)
-        okButton.tintColor = .sparkGray
-        okButton.backgroundColor = .sparkWhite
-        considerButton.isEnabled = false
-        considerButton.layer.borderColor = UIColor.sparkGray.cgColor
-        considerButton.setTitleColor(.sparkGray, for: .normal)
-        considerButton.tintColor = .sparkGray
-        considerButton.backgroundColor = .sparkWhite
-        setConsiderRestWithAPI(statusType: "REST")
-        dismiss(animated: true, completion: nil)
+        let presentingVC = presentingViewController
+        dismiss(animated: true) {
+            guard let dialogueVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
+            
+            dialogueVC.dialogueType = .rest
+            dialogueVC.clousure = {
+                self.setConsiderRestWithAPI(statusType: "REST")
+            }
+            dialogueVC.modalTransitionStyle = .crossDissolve
+            dialogueVC.modalPresentationStyle = .overFullScreen
+            
+            presentingVC?.present(dialogueVC, animated: true, completion: nil)
+        }
     }
 }
 
@@ -187,8 +187,9 @@ extension HabitAuthVC {
         RoomAPI.shared.setConsiderRest(roomID: roomID ?? 0, statusType: statusType) {  response in
             switch response {
             case .success(let message):
-                self.dismiss(animated: true, completion: nil)
-                NotificationCenter.default.post(name: .updateHabitRoom, object: nil)
+                self.dismiss(animated: true) {
+                    NotificationCenter.default.post(name: .updateHabitRoom, object: nil)
+                }
                 print("setConsiderRestWithAPI - success: \(message)")
             case .requestErr(let message):
                 print("setConsiderRestWithAPI - requestErr: \(message)")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
@@ -159,7 +159,9 @@ extension HabitAuthVC {
     
     @objc
     private func touchConsiderButton() {
-        setConsiderRestWithAPI(statusType: "CONSIDER")
+        self.dismiss(animated: true) {
+            self.setConsiderRestWithAPI(statusType: "CONSIDER")
+        }
     }
     
     @objc
@@ -187,9 +189,7 @@ extension HabitAuthVC {
         RoomAPI.shared.setConsiderRest(roomID: roomID ?? 0, statusType: statusType) {  response in
             switch response {
             case .success(let message):
-                self.dismiss(animated: true) {
-                    NotificationCenter.default.post(name: .updateHabitRoom, object: nil)
-                }
+                NotificationCenter.default.post(name: .updateHabitRoom, object: nil)
                 print("setConsiderRestWithAPI - success: \(message)")
             case .requestErr(let message):
                 print("setConsiderRestWithAPI - requestErr: \(message)")


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#314

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- DialogueVC 에 쉴래요 케이스 추가
- 쉴래요 선택시 다이얼로그 등장

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- `setConsiderRestWithAPI` 서버통신에서 dismiss 를 처리중이어서 삭제함
> @yangsubinn @L-j-h-c 
-> 이후, 추가 커밋으로 (33e455d) 서버통신에 있던 dismiss 로직 삭제함. DialogueVC 로 closure 를 넘겼을때 dismiss 가 중복되고 있기때문에 서버코드에서 dismiss 를 분리해냄.
- 다이얼로그 취소 애니메이션은 수빈선배가 전 풀리퀘에서 수정하셨는데 보고싶어서 저도 수정해뒀습니당

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|쉴래요 나도..쉴래요|<img src = "https://user-images.githubusercontent.com/69136340/155874692-8c883c09-0936-42ed-a0c7-8763c084ac8c.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #314
