### PR TITLE
[Feat] #310 - 방 생성 완료 뷰 구현

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		2B98520E2790AE0000CE40A7 /* PhotoAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B98520D2790AE0000CE40A7 /* PhotoAuthView.swift */; };
 		2B9C6BCB279277D600CD914F /* GoalWriting.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2B9C6BCA279277D600CD914F /* GoalWriting.storyboard */; };
 		2B9C6BCE2792781F00CD914F /* GoalWritingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9C6BCD2792781F00CD914F /* GoalWritingVC.swift */; };
+		2BA98FB627CB620E00C53820 /* CreateSuccessVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA98FB527CB620E00C53820 /* CreateSuccessVC.swift */; };
+		2BA98FB827CB621B00C53820 /* CreateSuccess.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2BA98FB727CB621B00C53820 /* CreateSuccess.storyboard */; };
 		2BBED12D279539B90052CA5C /* WaitingMember.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBED12C279539B90052CA5C /* WaitingMember.swift */; };
 		2BBED13027956C9F0052CA5C /* Feed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBED12F27956C9F0052CA5C /* Feed.swift */; };
 		2BBED13327956D170052CA5C /* FeedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBED13227956D170052CA5C /* FeedService.swift */; };
@@ -182,6 +184,8 @@
 		2B98520D2790AE0000CE40A7 /* PhotoAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoAuthView.swift; sourceTree = "<group>"; };
 		2B9C6BCA279277D600CD914F /* GoalWriting.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = GoalWriting.storyboard; sourceTree = "<group>"; };
 		2B9C6BCD2792781F00CD914F /* GoalWritingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalWritingVC.swift; sourceTree = "<group>"; };
+		2BA98FB527CB620E00C53820 /* CreateSuccessVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSuccessVC.swift; sourceTree = "<group>"; };
+		2BA98FB727CB621B00C53820 /* CreateSuccess.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CreateSuccess.storyboard; sourceTree = "<group>"; };
 		2BBED12C279539B90052CA5C /* WaitingMember.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitingMember.swift; sourceTree = "<group>"; };
 		2BBED12F27956C9F0052CA5C /* Feed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feed.swift; sourceTree = "<group>"; };
 		2BBED13227956D170052CA5C /* FeedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedService.swift; sourceTree = "<group>"; };
@@ -346,6 +350,7 @@
 			children = (
 				2B985204279031D000CE40A7 /* CreateRoomVC.swift */,
 				2B98520A2790AD0000CE40A7 /* CreateAuthVC.swift */,
+				2BA98FB527CB620E00C53820 /* CreateSuccessVC.swift */,
 			);
 			path = Create;
 			sourceTree = "<group>";
@@ -355,6 +360,7 @@
 			children = (
 				2B9852022790310800CE40A7 /* CreateRoom.storyboard */,
 				2B9852082790ACF000CE40A7 /* CreateAuth.storyboard */,
+				2BA98FB727CB621B00C53820 /* CreateSuccess.storyboard */,
 			);
 			path = Create;
 			sourceTree = "<group>";
@@ -1136,6 +1142,7 @@
 				EB625E99278F8EF200C43DE9 /* StorageMore.storyboard in Resources */,
 				EB625E80278F272300C43DE9 /* DoneStorageCVC.xib in Resources */,
 				F8FAA9732790344D00C4190F /* HomeHabitCVC.xib in Resources */,
+				2BA98FB827CB621B00C53820 /* CreateSuccess.storyboard in Resources */,
 				F8096F0B2784107D00B71D38 /* Home.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1236,6 +1243,7 @@
 				2B98520E2790AE0000CE40A7 /* PhotoAuthView.swift in Sources */,
 				F867B6B6278F86610024B1D4 /* UINavigationController+.swift in Sources */,
 				EB625E7F278F272300C43DE9 /* DoneStorageCVC.swift in Sources */,
+				2BA98FB627CB620E00C53820 /* CreateSuccessVC.swift in Sources */,
 				EBEA382D27947C9100B5736A /* MyRoomAPI.swift in Sources */,
 				2B69E7E7278E28B2000F927F /* FeedCVC.swift in Sources */,
 				2B0CF77427BFEDAC003C2E21 /* BottomButton.swift in Sources */,

--- a/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Storyboard.swift
@@ -23,6 +23,7 @@ extension Const {
             static let joinCheck = "JoinCheck"
             static let createRoom = "CreateRoom"
             static let createAuth = "CreateAuth"
+            static let createSuccess = "CreateSuccess"
             static let goalWriting = "GoalWriting"
             static let habitAuth = "HabitAuth"
             static let completeAuth = "CompleteAuth"

--- a/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/ViewController.swift
@@ -23,6 +23,7 @@ extension Const {
             static let joinCheck = "JoinCheckVC"
             static let createRoom = "CreateRoomVC"
             static let createAuth = "CreateAuthVC"
+            static let createSuccess = "CreateSuccessVC"
             static let goalWriting = "GoalWritingVC"
             static let habitAuth = "HabitAuthVC"
             static let completeAuth = "CompleteAuthVC"

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/CodeJoin/JoinCheck.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/CodeJoin/JoinCheck.storyboard
@@ -61,7 +61,7 @@
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                 <state key="normal" title="코드 다시 입력하기">
-                                    <color key="titleColor" name="sparkPinkRed"/>
+                                    <color key="titleColor" name="sparkDarkPinkRed"/>
                                 </state>
                                 <connections>
                                     <action selector="touchReinputCode:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="y2M-Ef-5u1"/>
@@ -155,9 +155,6 @@
         </namedColor>
         <namedColor name="sparkGray">
             <color red="0.6940000057220459" green="0.69800001382827759" blue="0.70599997043609619" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="sparkPinkRed">
-            <color red="1" green="0.13300000131130219" blue="0.34099999070167542" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="sparkWhite">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/Create/CreateSuccess.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/Create/CreateSuccess.storyboard
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--CreateSuccessVC-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="CreateSuccessVC" title="CreateSuccessVC" id="Y6W-OH-hqX" customClass="CreateSuccessVC" customModule="Spark_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="96"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/BottomButton.swift
@@ -7,35 +7,54 @@
 
 import UIKit
 
+import SnapKit
+
+@frozen
+enum BottomButtonType {
+    case pink
+    case white
+}
+
 class BottomButton: UIButton {
 
     // MARK: - Initialize
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setUI()
         setLayout()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        setUI()
         setLayout()
     }
     
     // MARK: - Method
-    
-    private func setUI() {
-        backgroundColor = .sparkDarkPinkred
-        titleLabel?.font = .enBoldFont(ofSize: 18)
-        layer.cornerRadius = 2
-    }
     
     private func setLayout() {
         self.snp.makeConstraints { make in
             make.width.equalTo(UIScreen.main.bounds.width - 40)
             make.height.equalTo((UIScreen.main.bounds.width - 40) * 48 / 335)
         }
+    }
+    
+    @discardableResult
+    func setUI(_ type: BottomButtonType) -> Self {
+        
+        titleLabel?.font = .enBoldFont(ofSize: 18)
+        layer.cornerRadius = 2
+        
+        switch type {
+        case .pink:
+            backgroundColor = .sparkDarkPinkred
+        case .white:
+            backgroundColor = .sparkWhite
+            setTitleColor(.sparkDarkPinkred, for: .normal)
+            layer.borderWidth = 1
+            layer.borderColor = UIColor.sparkDarkPinkred.cgColor
+        }
+        
+        return self
     }
     
     @discardableResult

--- a/Spark-iOS/Spark-iOS/Source/Extensions/UIViewController+.swift
+++ b/Spark-iOS/Spark-iOS/Source/Extensions/UIViewController+.swift
@@ -24,7 +24,7 @@ extension UIViewController {
         toastLabel.layer.cornerRadius = 2
         toastLabel.clipsToBounds = true
         self.view.addSubview(toastLabel)
-        UIView.animate(withDuration: 2.0, delay: 0.6,
+        UIView.animate(withDuration: 2.0, delay: 0.4,
                        options: .curveEaseIn, animations: { toastLabel.alpha = 0.0 },
                        completion: {_ in toastLabel.removeFromSuperview() })
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -20,7 +20,7 @@ class AuthTimerVC: UIViewController {
     private let betweenLine = UIView()
     private let divideLine = UIView()
     private let timeLabel = UILabel()
-    private let bottomButton = BottomButton()
+    private let bottomButton = BottomButton().setUI(.pink)
     private let pauseButton = UIButton()
     private let resetButton = UIButton()
     private let customNavigationBar = LeftButtonNavigaitonBar()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -28,7 +28,7 @@ class AuthUploadVC: UIViewController {
     private let stopwatchLabel = UILabel()
     private let photoLabel = UILabel()
     private let betweenLine = UIView()
-    private let photoAuthButton = BottomButton().setTitle("사진 인증하기")
+    private let photoAuthButton = BottomButton().setUI(.pink).setTitle("사진 인증하기")
     private let picker = UIImagePickerController()
     private var buttonStackView = UIStackView()
     private var uploadButton = UIButton()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
@@ -61,7 +61,7 @@ class JoinCheckVC: UIViewController {
 extension JoinCheckVC {
     private func setUI() {
         reInputButton.setTitleColor(.sparkLightPinkred, for: .highlighted)
-        reInputButton.layer.borderColor = UIColor.sparkLightPinkred.cgColor
+        reInputButton.layer.borderColor = UIColor.sparkDarkPinkred.cgColor
         reInputButton.layer.borderWidth = 2
         
         enterButton.setTitleColor(.white, for: .normal)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -30,7 +30,6 @@ class CreateAuthVC: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
         setUI()
         setLayout()
         setAddTarget()
@@ -88,28 +87,18 @@ class CreateAuthVC: UIViewController {
         
         dialogVC.dialogueType = .createRoom
         dialogVC.clousure = {
-            self.dismiss(animated: true, completion: nil)
-            // TODO: - dismiss 하고 서버 통신한 뒤 성공이면 새로운 뷰 띄워주기 -> 새로운 뷰에서 dismiss하고 rootVC 만들어서 움직이기
             self.postCreateRoomWithAPI(roomName: self.roomName, fromStart: !self.photoOnly) {
-                print("새로운 팝업 띄울거임 ㅋ")
+                guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.createSuccess, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.createSuccess) as? CreateSuccessVC else { return }
+                
+                nextVC.roomName = self.roomName
+                nextVC.roomId = self.roomId
+
+                self.navigationController?.pushViewController(nextVC, animated: true)
             }
         }
         dialogVC.modalPresentationStyle = .overFullScreen
         dialogVC.modalTransitionStyle = .crossDissolve
         present(dialogVC, animated: true, completion: nil)
-        
-//        postCreateRoomWithAPI(roomName: roomName, fromStart: !photoOnly) {
-//            guard let rootVC = UIStoryboard(name: Const.Storyboard.Name.waiting, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.waiting) as? WaitingVC else { return }
-//            rootVC.roomName = self.roomName
-//            rootVC.roomId = self.roomId
-//            rootVC.fromWhereStatus = .makeRoom
-//
-//            let nextVC = UINavigationController(rootViewController: rootVC)
-//            nextVC.modalTransitionStyle = .crossDissolve
-//            nextVC.modalPresentationStyle = .fullScreen
-//
-//            self.present(nextVC, animated: true)
-//        }
     }
     
     @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -18,7 +18,7 @@ class CreateAuthVC: UIViewController {
     private let subTitleLabel = UILabel()
     private let photoAuthView = PhotoAuthView()
     private let timerAuthView = TimerAuthView()
-    private let enterButton = BottomButton().setTitle("대기방 입장하기")
+    private let createButton = BottomButton().setTitle("습관방 만들기")
     private let customNavigationBar = LeftButtonNavigaitonBar()
     
     /// photoOnly가 true이면 fromStart가 false
@@ -79,23 +79,37 @@ class CreateAuthVC: UIViewController {
     }
     
     private func setAddTarget() {
-        enterButton.addTarget(self, action: #selector(touchEnterButton), for: .touchUpInside)
+        createButton.addTarget(self, action: #selector(touchCreateButton), for: .touchUpInside)
     }
     
     @objc
-    private func touchEnterButton() {
-        postCreateRoomWithAPI(roomName: roomName, fromStart: !photoOnly) {
-            guard let rootVC = UIStoryboard(name: Const.Storyboard.Name.waiting, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.waiting) as? WaitingVC else { return }
-            rootVC.roomName = self.roomName
-            rootVC.roomId = self.roomId
-            rootVC.fromWhereStatus = .makeRoom
-            
-            let nextVC = UINavigationController(rootViewController: rootVC)
-            nextVC.modalTransitionStyle = .crossDissolve
-            nextVC.modalPresentationStyle = .fullScreen
-            
-            self.present(nextVC, animated: true)
+    private func touchCreateButton() {
+        guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
+        
+        dialogVC.dialogueType = .createRoom
+        dialogVC.clousure = {
+            self.dismiss(animated: true, completion: nil)
+            // TODO: - dismiss 하고 서버 통신한 뒤 성공이면 새로운 뷰 띄워주기 -> 새로운 뷰에서 dismiss하고 rootVC 만들어서 움직이기
+            self.postCreateRoomWithAPI(roomName: self.roomName, fromStart: !self.photoOnly) {
+                print("새로운 팝업 띄울거임 ㅋ")
+            }
         }
+        dialogVC.modalPresentationStyle = .overFullScreen
+        dialogVC.modalTransitionStyle = .crossDissolve
+        present(dialogVC, animated: true, completion: nil)
+        
+//        postCreateRoomWithAPI(roomName: roomName, fromStart: !photoOnly) {
+//            guard let rootVC = UIStoryboard(name: Const.Storyboard.Name.waiting, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.waiting) as? WaitingVC else { return }
+//            rootVC.roomName = self.roomName
+//            rootVC.roomId = self.roomId
+//            rootVC.fromWhereStatus = .makeRoom
+//
+//            let nextVC = UINavigationController(rootViewController: rootVC)
+//            nextVC.modalTransitionStyle = .crossDissolve
+//            nextVC.modalPresentationStyle = .fullScreen
+//
+//            self.present(nextVC, animated: true)
+//        }
     }
     
     @objc
@@ -147,7 +161,7 @@ extension CreateAuthVC {
 // MARK: - Layout
 extension CreateAuthVC {
     private func setLayout() {
-        view.addSubviews([customNavigationBar, titleLabel, subTitleLabel, photoAuthView, timerAuthView, enterButton])
+        view.addSubviews([customNavigationBar, titleLabel, subTitleLabel, photoAuthView, timerAuthView, createButton])
         
         customNavigationBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
@@ -177,7 +191,7 @@ extension CreateAuthVC {
             make.height.equalTo(UIScreen.main.hasNotch ? 206 : 180)
         }
         
-        enterButton.snp.makeConstraints { make in
+        createButton.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
         }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -18,7 +18,7 @@ class CreateAuthVC: UIViewController {
     private let subTitleLabel = UILabel()
     private let photoAuthView = PhotoAuthView()
     private let timerAuthView = TimerAuthView()
-    private let createButton = BottomButton().setTitle("습관방 만들기")
+    private let createButton = BottomButton().setUI(.pink).setTitle("습관방 만들기")
     private let customNavigationBar = LeftButtonNavigaitonBar()
     
     /// photoOnly가 true이면 fromStart가 false

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -18,7 +18,7 @@ class CreateRoomVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private let nextButton = BottomButton().setTitle("다음으로").setDisable()
+    private let nextButton = BottomButton().setUI(.pink).setTitle("다음으로").setDisable()
     private let customNavigationBar = LeftButtonNavigaitonBar()
     private let maxLength: Int = 15
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -17,8 +17,13 @@ class CreateSuccessVC: UIViewController {
     private let guideLabel = UILabel()
     private let copyButton = UIButton()
     private let wantImageView = UIImageView()
-    private let homeButton = BottomButton()
-    private let enterButtno = BottomButton()
+    private let homeButton = BottomButton().setUI(.white).setTitle("홈으로 가기")
+    private let enterButton = BottomButton().setUI(.pink).setTitle("대기방 입장하기")
+    
+    var photoOnly: Bool?
+    var roomName: String?
+    var roomCode: String?
+    var roomId: Int?
     
     // MARK: - Life Cycles
     
@@ -32,16 +37,76 @@ class CreateSuccessVC: UIViewController {
     // MARK: - Custom Methods
     
     private func setUI() {
+        titleLabel.text = "30분 독서\n방을 만들었어요!"
+        titleLabel.font = .h2Title
+        titleLabel.textAlignment = .center
+        titleLabel.textColor = .sparkPinkred
+        titleLabel.partColorChange(targetString: "방을 만들었어요!", textColor: .sparkBlack)
+        titleLabel.numberOfLines = 2
         
-    }
-    
-    private func setLayout() {
+        guideLabel.text = "코드를 복사해 친구들을 초대해 보세요!"
+        guideLabel.font = .p1TitleLight
+        guideLabel.textAlignment = .center
+        guideLabel.textColor = .sparkDarkGray
         
+        copyButton.setImage(UIImage(named: "btnSmall"), for: .normal)
+        
+        wantImageView.backgroundColor = .gray
     }
     
     private func setAddTarget() {
-        
+        copyButton.addTarget(self, action: #selector(copyToClipboard), for: .touchUpInside)
+    }
+    
+    // MARK: - @objc
+    @objc
+    private func copyToClipboard() {
+        UIPasteboard.general.string = roomCode
+        showToast(x: 20, y: view.safeAreaInsets.top, message: "코드를 복사했어요!", font: .p1TitleLight)
     }
 }
 
 // MARK: - Network
+
+
+// MARK: - Layout
+extension CreateSuccessVC {
+    private func setLayout() {
+        view.addSubviews([titleLabel, guideLabel, copyButton,
+                         wantImageView, homeButton, enterButton])
+        
+        titleLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(68)
+        }
+        
+        guideLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(titleLabel.snp.bottom).offset(12)
+        }
+        
+        copyButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(guideLabel.snp.bottom).offset(20)
+            make.width.equalTo(87)
+            make.height.equalTo(36)
+        }
+        
+        wantImageView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.width.height.equalTo(300)
+            make.top.equalTo(copyButton.snp.bottom).offset(28)
+        }
+        
+        enterButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        homeButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(enterButton.snp.top).offset(-16)
+        }
+    }
+    
+}

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -20,7 +20,6 @@ class CreateSuccessVC: UIViewController {
     private let homeButton = BottomButton().setUI(.white).setTitle("홈으로 가기")
     private let enterButton = BottomButton().setUI(.pink).setTitle("대기방 입장하기")
     
-    var photoOnly: Bool?
     var roomName: String?
     var roomCode: String?
     var roomId: Int?
@@ -37,7 +36,7 @@ class CreateSuccessVC: UIViewController {
     // MARK: - Custom Methods
     
     private func setUI() {
-        titleLabel.text = "30분 독서\n방을 만들었어요!"
+        titleLabel.text = "\(roomName ?? "")\n방을 만들었어요!"
         titleLabel.font = .h2Title
         titleLabel.textAlignment = .center
         titleLabel.textColor = .sparkPinkred
@@ -56,18 +55,42 @@ class CreateSuccessVC: UIViewController {
     
     private func setAddTarget() {
         copyButton.addTarget(self, action: #selector(copyToClipboard), for: .touchUpInside)
+        homeButton.addTarget(self, action: #selector(touchHomeButton), for: .touchUpInside)
+        enterButton.addTarget(self, action: #selector(touchEnterButton), for: .touchUpInside)
     }
     
     // MARK: - @objc
+    
     @objc
     private func copyToClipboard() {
         UIPasteboard.general.string = roomCode
         showToast(x: 20, y: view.safeAreaInsets.top, message: "코드를 복사했어요!", font: .p1TitleLight)
     }
+    
+    @objc
+    private func touchHomeButton() {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @objc
+    private func touchEnterButton() {
+        guard let rootVC = UIStoryboard(name: Const.Storyboard.Name.waiting, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.waiting) as? WaitingVC else { return }
+        rootVC.roomName = self.roomName
+        rootVC.roomId = self.roomId
+        rootVC.fromWhereStatus = .makeRoom
+        
+        let nextVC = UINavigationController(rootViewController: rootVC)
+        nextVC.modalTransitionStyle = .crossDissolve
+        nextVC.modalPresentationStyle = .fullScreen
+        
+        self.present(nextVC, animated: true)
+    }
 }
 
 // MARK: - Network
-
+extension CreateSuccessVC {
+    // TODO: - 코드복사할 roomCode를 가져오기 위해 서버 통신
+}
 
 // MARK: - Layout
 extension CreateSuccessVC {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -1,0 +1,47 @@
+//
+//  CreateSuccessVC.swift
+//  Spark-iOS
+//
+//  Created by 양수빈 on 2022/02/27.
+//
+
+import UIKit
+
+import SnapKit
+
+class CreateSuccessVC: UIViewController {
+    
+    // MARK: - Properties
+
+    private let titleLabel = UILabel()
+    private let guideLabel = UILabel()
+    private let copyButton = UIButton()
+    private let wantImageView = UIImageView()
+    private let homeButton = BottomButton()
+    private let enterButtno = BottomButton()
+    
+    // MARK: - Life Cycles
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        setLayout()
+        setAddTarget()
+    }
+    
+    // MARK: - Custom Methods
+    
+    private func setUI() {
+        
+    }
+    
+    private func setLayout() {
+        
+    }
+    
+    private func setAddTarget() {
+        
+    }
+}
+
+// MARK: - Network

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -31,6 +31,7 @@ class CreateSuccessVC: UIViewController {
         setUI()
         setLayout()
         setAddTarget()
+        getRoomCodeWithAPI(roomId: self.roomId ?? 0)
     }
     
     // MARK: - Custom Methods
@@ -63,8 +64,10 @@ class CreateSuccessVC: UIViewController {
     
     @objc
     private func copyToClipboard() {
-        UIPasteboard.general.string = roomCode
-        showToast(x: 20, y: view.safeAreaInsets.top, message: "코드를 복사했어요!", font: .p1TitleLight)
+        if let roomCode = roomCode {
+            UIPasteboard.general.string = roomCode
+            showToast(x: 20, y: view.safeAreaInsets.top, message: "코드를 복사했어요!", font: .p1TitleLight)
+        }
     }
     
     @objc
@@ -89,7 +92,25 @@ class CreateSuccessVC: UIViewController {
 
 // MARK: - Network
 extension CreateSuccessVC {
-    // TODO: - 코드복사할 roomCode를 가져오기 위해 서버 통신
+    /// 방 코드 복사를 위해 대기방 API 통신
+    private func getRoomCodeWithAPI(roomId: Int) {
+        RoomAPI.shared.waitingFetch(roomID: roomId) { response in
+            switch response {
+            case .success(let data):
+                if let createSuccess = data as? Waiting {
+                    self.roomCode = createSuccess.roomCode
+                }
+            case .requestErr(let message):
+                print("getRoomCodeWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("getRoomCodeWithAPI - pathErr")
+            case .serverErr:
+                print("getRoomCodeWithAPI - serverErr")
+            case .networkFail:
+                print("getRoomCodeWithAPI - networkFail")
+            }
+        }
+    }
 }
 
 // MARK: - Layout
@@ -131,5 +152,4 @@ extension CreateSuccessVC {
             make.bottom.equalTo(enterButton.snp.top).offset(-16)
         }
     }
-    
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
@@ -15,6 +15,7 @@ enum DialogueType {
     case exitAuth
     case resetTimer
     case exitTimer
+    case createRoom
 }
 
 class DialogueVC: UIViewController {
@@ -80,6 +81,14 @@ extension DialogueVC {
             이미 측정한 시간 기록이 사라집니다.
             그래도 나가시겠습니까?
             """
+            
+        case .createRoom:
+            guideLabel.text = """
+            방 생성을 완료하시겠습니까?
+            방 이름과 인증 방식은 추후 수정이 어렵습니다.
+            """
+            resetOrExitLabel.text = "완료"
+            resetOrExitLabel.textColor = .sparkDarkPinkred
             
         case .none:
             print("dialogueType을 지정해주세요")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -26,7 +26,7 @@ class GoalWritingVC: UIViewController {
     private let goalTextField = UITextField()
     private let goalLineView = UIView()
     private let goalCountLabel = UILabel()
-    private let completeButton = BottomButton().setTitle("작성 완료").setDisable()
+    private let completeButton = BottomButton().setUI(.pink).setTitle("작성 완료").setDisable()
     private let maxLength: Int = 15
     
     var titleText: String?

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -21,7 +21,7 @@ class ProfileSettingVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private var completeButton = BottomButton().setTitle("가입완료").setDisable()
+    private var completeButton = BottomButton().setUI(.pink).setTitle("가입완료").setDisable()
     private let picker = UIImagePickerController()
     private let tap = UITapGestureRecognizer()
     private let maxLength: Int = 10

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -348,45 +348,81 @@ extension WaitingVC {
     }
     
     private func presentToMoreAlert() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alert.view.tintColor = .sparkDeepGray
+//        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+//        alert.view.tintColor = .sparkDeepGray
+//
+//        let delete = UIAlertAction(title: "방 삭제", style: .default) { _ in
+//            guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
+//
+//            dialogVC.dialogueType = .deleteWaitingRoom
+//            dialogVC.clousure = {
+//                self.deleteWaitingRoomWithAPI(roomID: self.roomId ?? 0)
+//            }
+//            dialogVC.modalPresentationStyle = .overFullScreen
+//            dialogVC.modalTransitionStyle = .crossDissolve
+//            self.present(dialogVC, animated: true, completion: nil)
+//        }
+//
+//        let leave = UIAlertAction(title: "방 나가기", style: .default) { _ in
+//            guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
+//
+//            dialogVC.dialogueType = .leaveWaitingRoom
+//            dialogVC.clousure = {
+//                self.leaveWaitingRoomWithAPI(roomID: self.roomId ?? 0)
+//            }
+//            dialogVC.modalPresentationStyle = .overFullScreen
+//            dialogVC.modalTransitionStyle = .crossDissolve
+//            self.present(dialogVC, animated: true, completion: nil)
+//        }
+//
+//        let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         
-        let delete = UIAlertAction(title: "방 삭제", style: .default) { _ in
-            guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
-            
-            dialogVC.dialogueType = .deleteWaitingRoom
-            dialogVC.clousure = {
-                self.deleteWaitingRoomWithAPI(roomID: self.roomId ?? 0)
-            }
-            dialogVC.modalPresentationStyle = .overFullScreen
-            dialogVC.modalTransitionStyle = .crossDissolve
-            self.present(dialogVC, animated: true, completion: nil)
-        }
-        
-        let leave = UIAlertAction(title: "방 나가기", style: .default) { _ in
-            guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
-            
-            dialogVC.dialogueType = .leaveWaitingRoom
-            dialogVC.clousure = {
-                self.leaveWaitingRoomWithAPI(roomID: self.roomId ?? 0)
-                print("방 나가야즹~")
-            }
-            dialogVC.modalPresentationStyle = .overFullScreen
-            dialogVC.modalTransitionStyle = .crossDissolve
-            self.present(dialogVC, animated: true, completion: nil)
-        }
-        
-        let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        let alert = SparkActionSheet()
         
         // 본인 방장 여부
         if self.isHost ?? true {
-            alert.addAction(delete)
+//            alert.addAction(delete)
+            alert.addAction(SparkAction("방 삭제", titleType: .blackMediumTitle, handler: {
+                alert.dismiss(animated: true) {
+                    guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
+                    
+                    dialogVC.dialogueType = .deleteWaitingRoom
+                    dialogVC.clousure = {
+                        self.deleteWaitingRoomWithAPI(roomID: self.roomId ?? 0)
+                    }
+                    dialogVC.modalPresentationStyle = .overFullScreen
+                    dialogVC.modalTransitionStyle = .crossDissolve
+                    self.present(dialogVC, animated: true, completion: nil)
+                }
+            }))
         } else {
-            alert.addAction(leave)
+//            alert.addAction(leave)
+            alert.addAction(SparkAction("방 나가기", titleType: .blackMediumTitle, handler: {
+                self.dismiss(animated: true) {
+                    guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
+                    
+                    dialogVC.dialogueType = .leaveWaitingRoom
+                    dialogVC.clousure = {
+                        self.leaveWaitingRoomWithAPI(roomID: self.roomId ?? 0)
+                    }
+                    dialogVC.modalPresentationStyle = .overFullScreen
+                    dialogVC.modalTransitionStyle = .crossDissolve
+                    self.present(dialogVC, animated: true, completion: nil)
+                }
+            }))
         }
-        alert.addAction(cancel)
         
-        present(alert, animated: true, completion: nil)
+        alert.addSection()
+        
+        alert.addAction(SparkAction("취소", titleType: .blackBoldTitle, handler: {
+            self.dismiss(animated: true, completion: nil)
+        }))
+        
+        present(alert, animated: true)
+                            
+//        alert.addAction(cancel)
+//
+//        present(alert, animated: true, completion: nil)
     }
     
     // MARK: - Screen Change

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -47,7 +47,7 @@ class WaitingVC: UIViewController {
     private let friendCountLabel = UILabel()
     private let friendSubTitleLabel = UILabel()
     private let refreshButton = UIButton()
-    private let startButton = BottomButton().setTitle("습관 시작하기")
+    private let startButton = BottomButton().setUI(.pink).setTitle("습관 시작하기")
     
     private var customNavigationBar = LeftRightButtonsNavigationBar()
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -348,40 +348,9 @@ extension WaitingVC {
     }
     
     private func presentToMoreAlert() {
-//        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-//        alert.view.tintColor = .sparkDeepGray
-//
-//        let delete = UIAlertAction(title: "방 삭제", style: .default) { _ in
-//            guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
-//
-//            dialogVC.dialogueType = .deleteWaitingRoom
-//            dialogVC.clousure = {
-//                self.deleteWaitingRoomWithAPI(roomID: self.roomId ?? 0)
-//            }
-//            dialogVC.modalPresentationStyle = .overFullScreen
-//            dialogVC.modalTransitionStyle = .crossDissolve
-//            self.present(dialogVC, animated: true, completion: nil)
-//        }
-//
-//        let leave = UIAlertAction(title: "방 나가기", style: .default) { _ in
-//            guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
-//
-//            dialogVC.dialogueType = .leaveWaitingRoom
-//            dialogVC.clousure = {
-//                self.leaveWaitingRoomWithAPI(roomID: self.roomId ?? 0)
-//            }
-//            dialogVC.modalPresentationStyle = .overFullScreen
-//            dialogVC.modalTransitionStyle = .crossDissolve
-//            self.present(dialogVC, animated: true, completion: nil)
-//        }
-//
-//        let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
-        
         let alert = SparkActionSheet()
-        
         // 본인 방장 여부
         if self.isHost ?? true {
-//            alert.addAction(delete)
             alert.addAction(SparkAction("방 삭제", titleType: .blackMediumTitle, handler: {
                 alert.dismiss(animated: true) {
                     guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
@@ -396,7 +365,6 @@ extension WaitingVC {
                 }
             }))
         } else {
-//            alert.addAction(leave)
             alert.addAction(SparkAction("방 나가기", titleType: .blackMediumTitle, handler: {
                 self.dismiss(animated: true) {
                     guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
@@ -419,10 +387,6 @@ extension WaitingVC {
         }))
         
         present(alert, animated: true)
-                            
-//        alert.addAction(cancel)
-//
-//        present(alert, animated: true, completion: nil)
     }
     
     // MARK: - Screen Change


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#310

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
-  방 생성 완료 뷰 레이아웃
-  방 생성 플로우 다이얼로그 추가
-  플로우 수정
-  BottomButton 수정
-  대기방 커스텀 액션시트 적용

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 방 생성 완료 뷰에 있는 회색 부분은 일러스트? 로티? 뭐가 들어갈지 모르겠어서 일단은 임의로 imageView 넣어뒀슴니다.
요 친구는 추후에 수정할게여!
- BottomButton setUI 부분을 두가지로 구분했습니다.
하얀색 배경의 버튼인 경우는 `.setUI(.white)` , 핑크색 배경의 버튼은 `.setUI(.pink)`로 사용하시면 됩니다.
- Joincheck 뷰에서 하단의 하얀 버튼 테두리 컬러가 다르다는 디자인의 은밀한 큐에이 전달로 살짝 수정했습니다
- 다이얼로그로 방 생성하고, 방 생성 완료 뷰로 넘어가는 인터렉션은 따로 전달받지 않았고 그냥 맘대로.. 구현했습니다.
원래는 방생성하는 플로우를 dismiss 하고 홈에서 present 시켜서 거기서 대기방가기를 눌렀을 경우 dismiss 후 present 시키는 등등...
present하는 식으로 할까 하다가 그럼 막 띄웠다가 내렸다가 복잡해지는 것 같아서
그냥 push를 해서 화면 전환 코드를 비교적 간단하게 짰습니다..

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 방 생성 완료 후 홈 |<img src = "https://user-images.githubusercontent.com/81167570/155941241-bf5045aa-dad2-4010-bd56-6ab02d7aaea8.gif" width ="250">|
| 방 생성 완료 후 대기방 | <img src="https://user-images.githubusercontent.com/81167570/156098981-5322da59-b009-4165-bbd9-28ebe790840c.gif" width="250">






## 📟 관련 이슈
- Resolved: #310 
