### PR TITLE
[Feat] #317 - customActionSheet coverVertical 애니메이션 구현

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.swift
@@ -43,7 +43,7 @@ class MoreStorageCVC: UICollectionViewCell {
     @IBOutlet weak var timerLabel: UILabel!
     @IBOutlet weak var timerAlphaView: UIView!
     
-    // MARK: - Initializer
+    // MARK: - View Life Cycle
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/Spark-iOS/Spark-iOS/Source/Classes/SparkActionSheet.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/SparkActionSheet.swift
@@ -296,18 +296,33 @@ extension SparkActionSheet {
 
 extension SparkActionSheet {
     private func upAnimation() {
-        UIView.animate(withDuration: 0.2,
-                       delay: 0,
-                       options: .curveEaseInOut) {
-            
-            let frame = CGAffineTransform(translationX: 0, y: UIScreen.main.bounds.height - self.sparkActionMainStackView.bounds.height - 54 - self.sparkActionMainStackView.frame.origin.y)
+        let screenHeight: CGFloat = UIScreen.main.bounds.height
+        let actionSheetHeight: CGFloat = self.sparkActionMainStackView.frame.height
+        let actionSheetBottomMargin: CGFloat = 54
+        let actionSheetStartOriginY: CGFloat = self.sparkActionMainStackView.frame.origin.y
+        
+        UIView.animate(withDuration: 0.1,
+                       delay: 0.02,
+                       options: .curveEaseIn) {
+            let frame = CGAffineTransform(translationX: 0,
+                                          y: screenHeight - actionSheetHeight - actionSheetBottomMargin
+                                          - actionSheetStartOriginY)
             self.sparkActionMainStackView.transform = frame
         }
     }
     
     private func downAnimation() {
-        UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
-            let frame = CGAffineTransform(translationX: 0, y: UIScreen.main.bounds.height - self.sparkActionMainStackView.bounds.height - 54 - self.sparkActionMainStackView.frame.origin.y)
+        let screenHeight: CGFloat = UIScreen.main.bounds.height
+        let actionSheetHeight: CGFloat = self.sparkActionMainStackView.frame.height
+        let actionSheetBottomMargin: CGFloat = 54
+        let actionSheetStartOriginY: CGFloat = self.sparkActionMainStackView.frame.origin.y
+        
+        UIView.animate(withDuration: 0.1,
+                       delay: 0,
+                       options: .curveEaseInOut) {
+            let frame = CGAffineTransform(translationX: 0,
+                                          y: screenHeight - actionSheetHeight - actionSheetBottomMargin
+                                          - actionSheetStartOriginY)
             self.sparkActionMainStackView.transform = frame
         } completion: { _ in
             self.dismiss(animated: true, completion: nil)

--- a/Spark-iOS/Spark-iOS/Source/Classes/SparkActionSheet.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/SparkActionSheet.swift
@@ -192,7 +192,7 @@ class SparkActionSheet: UIViewController {
         super.viewWillAppear(animated)
         setLayout()
         makeActionSheet()
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now()) {
+        DispatchQueue.main.async {
             self.upAnimation()
         }
     }
@@ -200,7 +200,6 @@ class SparkActionSheet: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         sparkActionMainStackView.reset()
         sections = [SparkSection]()
-        downAnimation()
     }
     
     // MARK: - Methods
@@ -226,7 +225,7 @@ class SparkActionSheet: UIViewController {
     
     @objc
     private func tapGestureDidRecognize(_ gesture: UITapGestureRecognizer) {
-        self.dismiss(animated: true)
+        animatedDismiss()
     }
 }
 
@@ -251,7 +250,7 @@ extension SparkActionSheet {
         
         sparkActionMainStackView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
-            make.bottom.equalToSuperview().offset(sparkActionMainStackView.frame.height)
+            make.bottom.equalToSuperview().offset(sparkActionMainStackView.frame.height+150)
         }
     }
     
@@ -285,13 +284,19 @@ extension SparkActionSheet {
             }
         }
     }
+    
+    /// System Alert에서 dismiss 애니메이션과 같은 효과
+    func animatedDismiss(completion: (() -> Void)? = nil) {
+        downAnimation()
+        completion?()
+    }
 }
 
 // MARK: - Animation
 
 extension SparkActionSheet {
     private func upAnimation() {
-        UIView.animate(withDuration: 0.3,
+        UIView.animate(withDuration: 0.2,
                        delay: 0,
                        options: .curveEaseInOut) {
             
@@ -301,12 +306,11 @@ extension SparkActionSheet {
     }
     
     private func downAnimation() {
-        UIView.animate(withDuration: 0.4,
-                       delay: 0,
-                       options: .curveEaseInOut) {
-
-            let frame = CGAffineTransform(translationX: 0, y: self.sparkActionMainStackView.frame.height)
+        UIView.animate(withDuration: 0.1, delay: 0, options: .curveEaseInOut) {
+            let frame = CGAffineTransform(translationX: 0, y: UIScreen.main.bounds.height - self.sparkActionMainStackView.bounds.height - 54 - self.sparkActionMainStackView.frame.origin.y)
             self.sparkActionMainStackView.transform = frame
+        } completion: { _ in
+            self.dismiss(animated: true, completion: nil)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Classes/SparkActionSheet.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/SparkActionSheet.swift
@@ -192,11 +192,15 @@ class SparkActionSheet: UIViewController {
         super.viewWillAppear(animated)
         setLayout()
         makeActionSheet()
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now()) {
+            self.upAnimation()
+        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         sparkActionMainStackView.reset()
         sections = [SparkSection]()
+        downAnimation()
     }
     
     // MARK: - Methods
@@ -247,7 +251,7 @@ extension SparkActionSheet {
         
         sparkActionMainStackView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(20)
-            make.bottom.equalToSuperview().inset(54)
+            make.bottom.equalToSuperview().offset(sparkActionMainStackView.frame.height)
         }
     }
     
@@ -279,6 +283,30 @@ extension SparkActionSheet {
                 let spacer = sections[i].makeSectionSpacer()
                 sparkActionMainStackView.addArrangedSubview(spacer)
             }
+        }
+    }
+}
+
+// MARK: - Animation
+
+extension SparkActionSheet {
+    private func upAnimation() {
+        UIView.animate(withDuration: 0.3,
+                       delay: 0,
+                       options: .curveEaseInOut) {
+            
+            let frame = CGAffineTransform(translationX: 0, y: UIScreen.main.bounds.height - self.sparkActionMainStackView.bounds.height - 54 - self.sparkActionMainStackView.frame.origin.y)
+            self.sparkActionMainStackView.transform = frame
+        }
+    }
+    
+    private func downAnimation() {
+        UIView.animate(withDuration: 0.4,
+                       delay: 0,
+                       options: .curveEaseInOut) {
+
+            let frame = CGAffineTransform(translationX: 0, y: self.sparkActionMainStackView.frame.height)
+            self.sparkActionMainStackView.transform = frame
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -227,7 +227,7 @@ extension AuthUploadVC {
         alert.addSection()
         
         alert.addAction(SparkAction("취소", titleType: .blackBoldTitle, buttonFont: .krBoldFont(ofSize: 16), handler: {
-            self.dismiss(animated: true, completion: nil)
+            alert.animatedDismiss(completion: nil)
         }))
         
         present(alert, animated: true)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -274,7 +274,7 @@ extension HabitRoomVC {
         alert.addSection()
         
         alert.addAction(SparkAction("취소", titleType: .blackBoldTitle, handler: {
-            self.dismiss(animated: true, completion: nil)
+            alert.animatedDismiss(completion: nil)
         }))
         
         present(alert, animated: true)
@@ -323,7 +323,7 @@ extension HabitRoomVC {
         alert.addSection()
         
         alert.addAction(SparkAction("취소", titleType: .blackBoldTitle, handler: {
-            self.dismiss(animated: true, completion: nil)
+            alert.animatedDismiss(completion: nil)
         }))
         
         present(alert, animated: true)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -138,7 +138,7 @@ class ProfileSettingVC: UIViewController {
         alert.addSection()
         
         alert.addAction(SparkAction("취소", titleType: .blackBoldTitle, handler: {
-            self.dismiss(animated: true, completion: nil)
+            alert.animatedDismiss(completion: nil)
         }))
         
         present(alert, animated: true)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -145,7 +145,7 @@ extension StorageMoreVC {
         alert.addSection()
         
         alert.addAction(SparkAction("취소", titleType: .blackBoldTitle, handler: {
-            self.dismiss(animated: true, completion: nil)
+            alert.animatedDismiss(completion: nil)
         }))
         
         present(alert, animated: true)


### PR DESCRIPTION
## 🔥*Pull requests*
customActionSheet coverVertical 애니메이션 구현

⛳️ **작업한 브랜치**
- feature/#317

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
시스템 alert처럼 스르륵 올라가고 내려오는 애니메이션을 구현했습니다..
animate를 써야 했던 이유는 transitionStyle에서 coverVertical로 지정하면 반투명한 배경이 올라가는게 같이 보여버리셔서..

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 1️⃣ 적용된 부분
1. 액션시트가 올라온 상태에서 배경을 터치하면 downAnimation이 발동합니다.
2. 현재 액션시트가 사용되고 있는 모든 뷰에서 취소 버튼에 대해서만 animatedDismiss를 적용했습니다.
이유는 다른 버튼을 선택했을 때에는 crossDisolve로 사라지고 특정한 액션이 취해지는 모습이 나름 자연스러워 보였기 떄무네...
(ex : '앨범에서 선택하기'를 터치하면 앨범이 올라오기 때문에 downAnimation이 크게 중요하지 않다...는 개인적인 판단)
3. upAnimation은 항상 발동합니다.
### 2️⃣ animatedDismiss에 대해
```swift
/// 정의
func animatedDismiss(completion: (() -> Void)? = nil) {
    downAnimation()
    completion?()
}

/// 사용
alert.addAction(SparkAction("취소", titleType: .blackBoldTitle, handler: {
    alert.animatedDismiss(completion: nil)
}))
```
요렇게 생겼습니다. 사용하실 때에 원하시는 컴플리션 넣어주시면 됩니다!

### ⁉️ 질문
```swift
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    setLayout()
    makeActionSheet()
    DispatchQueue.main.async {
        self.upAnimation()
    }
}
```
위와 같이 액션시트가 present될 때마다 upAnimation을 실행해주고 있는데, 저기서 디스패치큐를 사용해야만 `self.sparkActionMainStackView.frame.height`의 값이 잡혔습니다(디스패치큐 없이는 0으로 나옴). 라이프사이클에 관련된 문제인 건 알겠지만 async를 쓴다고 해서 지연 실행되는 것도 아닌데 레이아웃이 잡힌 이후에 downAnimation의 실행하는 것이 보장되는 이유가 있을까여...?

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/77208067/156014947-da6dcabf-f768-41fb-ad2d-055a8045f83a.mp4" width ="250">|

## 📟 관련 이슈
- Resolved: #317 
