### PR TITLE
[Refactor] #324 - 습관방 리프레시 메서드 네이밍 변경

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -312,7 +312,7 @@ extension HabitRoomVC {
     
     private func initRefreshControl() {
         refreshControl.tintColor = .sparkPinkred
-        refreshControl.addTarget(self, action: #selector(updateMemeber), for: .valueChanged)
+        refreshControl.addTarget(self, action: #selector(updateWithRefreshControll), for: .valueChanged)
         mainCollectionView.refreshControl = refreshControl
     }
     
@@ -369,7 +369,7 @@ extension HabitRoomVC {
     }
     
     @objc
-    private func updateMemeber() {
+    private func updateWithRefreshControll() {
         DispatchQueue.main.async {
             self.fetchHabitRoomDetailWithAPI(roomID: self.roomID ?? 0) {
                 self.refreshControl.endRefreshing()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -312,7 +312,7 @@ extension HabitRoomVC {
     
     private func initRefreshControl() {
         refreshControl.tintColor = .sparkPinkred
-        refreshControl.addTarget(self, action: #selector(updateWithRefreshControll), for: .valueChanged)
+        refreshControl.addTarget(self, action: #selector(updateWithRefreshControl), for: .valueChanged)
         mainCollectionView.refreshControl = refreshControl
     }
     
@@ -369,7 +369,7 @@ extension HabitRoomVC {
     }
     
     @objc
-    private func updateWithRefreshControll() {
+    private func updateWithRefreshControl() {
         DispatchQueue.main.async {
             self.fetchHabitRoomDetailWithAPI(roomID: self.roomID ?? 0) {
                 self.refreshControl.endRefreshing()


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#324

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 로직변경없이 작업하다보니 습관방 리프레시 메서드의 용도가 달라져 네이밍 변경
- `updateMember` -> `updateWithRefreshControl` 변경

## 📟 관련 이슈
- Resolved: #324
