### PR TITLE
[Feat] #336 - 방 나간 뒤 홈에서 토스트메세지 띄우기

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -318,6 +318,10 @@ extension HabitRoomVC {
         mainCollectionView.refreshControl = refreshControl
     }
     
+    private func postNoti() {
+        NotificationCenter.default.post(name: NSNotification.Name("leaveRoom"), object: nil, userInfo: ["roomName": "\(roomName ?? "")", "waitingRoom": false])
+    }
+    
     private func presentToMoreAlert() {
         let alert = SparkActionSheet()
         alert.addAction(SparkAction("나의 목표 수정", titleType: .blackMediumTitle, handler: {
@@ -527,6 +531,7 @@ extension HabitRoomVC {
             switch response {
             case .success(let message):
                 self.navigationController?.popViewController(animated: true)
+                self.postNoti()
                 print("deleteWaitingRoomWithAPI - success: \(message)")
             case .requestErr(let message):
                 print("deleteWaitingRoomWithAPI - requestErr: \(message)")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -39,6 +39,7 @@ class HomeVC: UIViewController {
         setDelegate()
         registerXib()
         initRefreshControl()
+        setNoti()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -142,6 +143,10 @@ extension HomeVC {
         mainCollectionView.refreshControl = refreshControl
     }
     
+    private func setNoti() {
+        NotificationCenter.default.addObserver(self, selector: #selector(setToastMessage(_:)), name: NSNotification.Name("leaveRoom"), object: nil)
+    }
+    
     // MARK: - Screen Change
     
     private func presentToProfileVC() {
@@ -162,6 +167,24 @@ extension HomeVC {
         DispatchQueue.main.async {
             self.habitRoomFetchWithAPI(lastID: self.habitRoomLastID) {
                 self.refreshControl.endRefreshing()
+            }
+        }
+    }
+    
+    @objc
+    private func setToastMessage(_ notification: NSNotification) {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.4) {
+            let roomName = notification.userInfo!["roomName"] ?? ""
+            let message: String
+            
+            if let waiting = notification.userInfo!["waitingRoom"] as? Bool {
+                if waiting {
+                    message = "'\(roomName)' 대기방을 나갔어요."
+                } else {
+                    message = "'\(roomName)' 방을 나갔어요."
+                }
+                
+                self.showToast(x: 20, y: self.view.safeAreaInsets.top, message: message, font: .p1TitleLight)
             }
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -174,8 +174,13 @@ extension HomeVC {
     @objc
     private func setToastMessage(_ notification: NSNotification) {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.4) {
-            let roomName = notification.userInfo!["roomName"] ?? ""
+            var roomName: String = notification.userInfo!["roomName"] as? String ?? ""
             let message: String
+        
+            if roomName.count > 8 {
+                let index = roomName.index(roomName.startIndex, offsetBy: 8)
+                roomName = roomName[..<index] + "..."
+            }
             
             if let waiting = notification.userInfo!["waitingRoom"] as? Bool {
                 if waiting {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -490,6 +490,10 @@ extension WaitingVC {
         
         self.present(nextVC, animated: true, completion: nil)
     }
+    
+    private func postNoti() {
+        NotificationCenter.default.post(name: NSNotification.Name("leaveRoom"), object: nil, userInfo: ["roomName": "\(roomName ?? "")", "waitingRoom": true])
+    }
 }
 
 // MARK: - Network
@@ -553,6 +557,7 @@ extension WaitingVC {
                 case .none:
                     print("fromeWhereStatus 를 지정해주세요.")
                 }
+                self.postNoti()
                 print("deleteWaitingRoomWithAPI - success: \(message)")
             case .requestErr(let message):
                 print("deleteWaitingRoomWithAPI - requestErr: \(message)")
@@ -581,6 +586,7 @@ extension WaitingVC {
                 case .none:
                     print("fromeWhereStatus 를 지정해주세요.")
                 }
+                self.postNoti()
                 print("deleteWaitingRoomWithAPI - success: \(message)")
             case .requestErr(let message):
                 print("deleteWaitingRoomWithAPI - requestErr: \(message)")


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#336

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
습관방, 대기방 모두 나간 뒤 홈에서 토스트메세지 띄우기



## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
노티를 사용했슴니다
- 각 방에서 서버통신 후 success라면 leaveRoom이라는 이름의 노티 보냄
- 홈에서 받아서 보여줌

주의사항
- 홈에서 로딩이 있기 때문에 `delay`를 주지 않으면 보이지 않는.. 문제가 있었습니다 
그래서 `aysncAfter`을 사용했습니다.
- 노티 보낼때 `방이름`과, `해당 방이 대기방인지 여부`를 함께 보내서 
홈에서 사용했습니다.



## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|나가기|<img src = "https://user-images.githubusercontent.com/81167570/156505668-3e1febe1-7f84-40c6-b836-7f9a855e8900.PNG" width ="250">|
|또 나가기 | <img src="https://user-images.githubusercontent.com/81167570/156505688-3bb94f3c-d462-44f0-a7c1-3bfc5e20b723.PNG" width="250"> |




## 📟 관련 이슈
- Resolved: #336 
