### PR TITLE
[Feat] #350 - 로그아웃 구현

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/DialogueVC.swift
@@ -20,6 +20,7 @@ enum DialogueType {
     case leaveWaitingRoom
     case createRoom
     case exitEditProfile
+    case logout
 }
 
 class DialogueVC: UIViewController {
@@ -119,6 +120,12 @@ extension DialogueVC {
             프로필 수정이 완료되지 않았습니다.
             그래도 나가시겠습니까?
             """
+            
+        case .logout:
+            guideLabel.text = """
+            로그아웃 하시겠습니까?
+            """
+            resetOrExitLabel.text = "로그아웃"
             
         case .none:
             print("dialogueType을 지정해주세요")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -128,6 +128,15 @@ extension MypageVC: UITableViewDelegate {
             editProfileVC.profileImageDelegate = self
             editProfileVC.modalPresentationStyle = .overFullScreen
             present(editProfileVC, animated: true, completion: nil)
+        } else if indexPath.section == 3, indexPath.row == 3 {
+            // logout
+            guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
+            
+            loginVC.modalTransitionStyle = .crossDissolve
+            loginVC.modalPresentationStyle = .fullScreen
+            present(loginVC, animated: true) {
+                UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+            }
         }
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -130,13 +130,21 @@ extension MypageVC: UITableViewDelegate {
             present(editProfileVC, animated: true, completion: nil)
         } else if indexPath.section == 3, indexPath.row == 3 {
             // logout
-            guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
+            guard let dialougeVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
             
-            loginVC.modalTransitionStyle = .crossDissolve
-            loginVC.modalPresentationStyle = .fullScreen
-            present(loginVC, animated: true) {
-                UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+            dialougeVC.dialogueType = .logout
+            dialougeVC.clousure = {
+                guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
+                
+                loginVC.modalTransitionStyle = .crossDissolve
+                loginVC.modalPresentationStyle = .fullScreen
+                self.present(loginVC, animated: true) {
+                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+                }
             }
+            dialougeVC.modalTransitionStyle = .crossDissolve
+            dialougeVC.modalPresentationStyle = .overFullScreen
+            present(dialougeVC, animated: true, completion: nil)
         }
     }
     


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#350

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 로그아웃 구현
> 엑세스 토큰을 삭제해주고 로그인 뷰로 이동시켰습니다.
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 로그아웃 다이얼로그는 임의로 만들었고, 문구가 정해지면 수정하겠습니당
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/69136340/157098563-281cd18f-be9b-49ec-9dee-8602efc66ccc.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #350
