### PR TITLE
[Design] #368 - 방생성 완료 뷰 로티 추가

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -64,7 +64,6 @@ class CreateSuccessVC: UIViewController {
     }
     
     private func setLottie() {
-        ticketLottieView.backgroundColor = .blue.withAlphaComponent(0.5)
         ticketLottieView.contentMode = .scaleAspectFit
         ticketLottieView.loopMode = .loop
         ticketLottieView.play()
@@ -154,10 +153,10 @@ extension CreateSuccessVC {
         }
         
         ticketLottieView.snp.updateConstraints { make in
-            make.leading.equalTo(sparkFlakeImageView.snp.leading).inset(94)
-            make.trailing.equalTo(sparkFlakeImageView.snp.trailing).inset(94)
-            make.top.equalTo(sparkFlakeImageView.snp.top).inset(72)
-            make.bottom.equalTo(sparkFlakeImageView.snp.bottom).inset(114)
+            make.centerX.equalToSuperview()
+            make.centerY.equalTo(sparkFlakeImageView.snp.centerY).offset(-18)
+            make.width.equalTo(sparkFlakeImageView.snp.width).multipliedBy(0.6)
+            make.height.equalTo(ticketLottieView.snp.width).multipliedBy(0.7)
         }
         
         enterButton.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import SnapKit
+import Lottie
 
 class CreateSuccessVC: UIViewController {
     
@@ -16,7 +17,8 @@ class CreateSuccessVC: UIViewController {
     private let titleLabel = UILabel()
     private let guideLabel = UILabel()
     private let copyButton = UIButton()
-    private let wantImageView = UIImageView()
+    private let sparkFlakeImageView = UIImageView()
+    private let ticketLottieView = AnimationView(name: Const.Lottie.Name.ticketWelcome)
     private let homeButton = BottomButton().setUI(.white).setTitle("홈으로 가기")
     private let enterButton = BottomButton().setUI(.pink).setTitle("대기방 입장하기")
     
@@ -50,14 +52,22 @@ class CreateSuccessVC: UIViewController {
         guideLabel.textColor = .sparkDarkGray
         
         copyButton.setImage(UIImage(named: "btnSmall"), for: .normal)
+        sparkFlakeImageView.image = UIImage(named: "sparkflakePattern")
         
-        wantImageView.backgroundColor = .gray
+        setLottie()
     }
     
     private func setAddTarget() {
         copyButton.addTarget(self, action: #selector(copyToClipboard), for: .touchUpInside)
         homeButton.addTarget(self, action: #selector(touchHomeButton), for: .touchUpInside)
         enterButton.addTarget(self, action: #selector(touchEnterButton), for: .touchUpInside)
+    }
+    
+    private func setLottie() {
+        ticketLottieView.backgroundColor = .blue.withAlphaComponent(0.5)
+        ticketLottieView.contentMode = .scaleAspectFit
+        ticketLottieView.loopMode = .loop
+        ticketLottieView.play()
     }
     
     // MARK: - @objc
@@ -117,7 +127,8 @@ extension CreateSuccessVC {
 extension CreateSuccessVC {
     private func setLayout() {
         view.addSubviews([titleLabel, guideLabel, copyButton,
-                         wantImageView, homeButton, enterButton])
+                         sparkFlakeImageView, ticketLottieView,
+                          homeButton, enterButton])
         
         titleLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
@@ -136,10 +147,17 @@ extension CreateSuccessVC {
             make.height.equalTo(36)
         }
         
-        wantImageView.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
-            make.width.height.equalTo(300)
+        sparkFlakeImageView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
             make.top.equalTo(copyButton.snp.bottom).offset(28)
+            make.height.equalTo(sparkFlakeImageView.snp.width).multipliedBy(0.86)
+        }
+        
+        ticketLottieView.snp.updateConstraints { make in
+            make.leading.equalTo(sparkFlakeImageView.snp.leading).inset(94)
+            make.trailing.equalTo(sparkFlakeImageView.snp.trailing).inset(94)
+            make.top.equalTo(sparkFlakeImageView.snp.top).inset(72)
+            make.bottom.equalTo(sparkFlakeImageView.snp.bottom).inset(114)
         }
         
         enterButton.snp.makeConstraints { make in


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#368

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
방생성 완료 뷰 로티 추가


## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 로티가 내부 마진 값을 갖고 있어서... 제플린의 티겟 사이즈에 맞추니 넘어온 디자인보다 사이즈가 작았습니다
- 그래서 눈대중으로 비슷하게 맞췄습니다


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| 방 생 성 완 료 |<img src = "https://user-images.githubusercontent.com/81167570/157702404-b3cb14cb-9257-4188-9b79-93b2cb712774.jpeg" width ="250">|



## 📟 관련 이슈
- Resolved: #368 
