### PR TITLE
[Feat] #364 - 알림뷰 서버 연결

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		2BE65F5127C3E34B005D370D /* RoomStart.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2BE65F5027C3E34B005D370D /* RoomStart.storyboard */; };
 		2BE907DF27D9EE7D00B36002 /* NoticeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE907DE27D9EE7D00B36002 /* NoticeAPI.swift */; };
 		2BE907E127D9EE9700B36002 /* NoticeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE907E027D9EE9700B36002 /* NoticeService.swift */; };
+		2BE907E427D9F1BB00B36002 /* ActiveNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE907E327D9F1BB00B36002 /* ActiveNotice.swift */; };
 		2BEA121D27BA1CB400B67756 /* HabitRoomMemberCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEA121C27BA1CB400B67756 /* HabitRoomMemberCVC.swift */; };
 		2BF3AB472794765F001A9042 /* RoomService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF3AB462794765F001A9042 /* RoomService.swift */; };
 		2BF3AB49279479B8001A9042 /* RoomAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF3AB48279479B8001A9042 /* RoomAPI.swift */; };
@@ -240,6 +241,7 @@
 		2BE65F5027C3E34B005D370D /* RoomStart.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RoomStart.storyboard; sourceTree = "<group>"; };
 		2BE907DE27D9EE7D00B36002 /* NoticeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAPI.swift; sourceTree = "<group>"; };
 		2BE907E027D9EE9700B36002 /* NoticeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeService.swift; sourceTree = "<group>"; };
+		2BE907E327D9F1BB00B36002 /* ActiveNotice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveNotice.swift; sourceTree = "<group>"; };
 		2BEA121C27BA1CB400B67756 /* HabitRoomMemberCVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HabitRoomMemberCVC.swift; sourceTree = "<group>"; };
 		2BF3AB462794765F001A9042 /* RoomService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomService.swift; sourceTree = "<group>"; };
 		2BF3AB48279479B8001A9042 /* RoomAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomAPI.swift; sourceTree = "<group>"; };
@@ -590,6 +592,14 @@
 			children = (
 				2BE907DE27D9EE7D00B36002 /* NoticeAPI.swift */,
 				2BE907E027D9EE9700B36002 /* NoticeService.swift */,
+			);
+			path = Notice;
+			sourceTree = "<group>";
+		};
+		2BE907E227D9F10E00B36002 /* Notice */ = {
+			isa = PBXGroup;
+			children = (
+				2BE907E327D9F1BB00B36002 /* ActiveNotice.swift */,
 			);
 			path = Notice;
 			sourceTree = "<group>";
@@ -988,6 +998,7 @@
 			children = (
 				F82F57FA27928437003E4174 /* NetworkResult.swift */,
 				F82F57FC2792847D003E4174 /* GenericResponse.swift */,
+				2BE907E227D9F10E00B36002 /* Notice */,
 				F8E3496B2796B7DF001B67E7 /* Auth */,
 				F82F5800279287EC003E4174 /* Home */,
 				2BF3AB4A27947C3A001A9042 /* Room */,
@@ -1389,6 +1400,7 @@
 				EB26D93827CF74D700C88DCA /* SendSparkCVC.swift in Sources */,
 				F8D4497227BE46670091F297 /* LeftRightButtonsNavigationBar.swift in Sources */,
 				2B54D01627D3B2810060DA06 /* FeedReportVC.swift in Sources */,
+				2BE907E427D9F1BB00B36002 /* ActiveNotice.swift in Sources */,
 				F8F6D6F7279735BF00725537 /* HabitRoomVC.swift in Sources */,
 				EB01BC1027C8DFBA00041A35 /* SparkActionSheet.swift in Sources */,
 				2BAF156327D4A0CA00DE4190 /* NoticeUpdateHeaderView.swift in Sources */,

--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		2BE5D818279330A6007A544D /* TimerAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE5D817279330A6007A544D /* TimerAuthView.swift */; };
 		2BE65F4F27C39595005D370D /* RoomStartVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE65F4E27C39595005D370D /* RoomStartVC.swift */; };
 		2BE65F5127C3E34B005D370D /* RoomStart.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2BE65F5027C3E34B005D370D /* RoomStart.storyboard */; };
+		2BE907DF27D9EE7D00B36002 /* NoticeAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE907DE27D9EE7D00B36002 /* NoticeAPI.swift */; };
+		2BE907E127D9EE9700B36002 /* NoticeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE907E027D9EE9700B36002 /* NoticeService.swift */; };
 		2BEA121D27BA1CB400B67756 /* HabitRoomMemberCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BEA121C27BA1CB400B67756 /* HabitRoomMemberCVC.swift */; };
 		2BF3AB472794765F001A9042 /* RoomService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF3AB462794765F001A9042 /* RoomService.swift */; };
 		2BF3AB49279479B8001A9042 /* RoomAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BF3AB48279479B8001A9042 /* RoomAPI.swift */; };
@@ -236,6 +238,8 @@
 		2BE5D817279330A6007A544D /* TimerAuthView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimerAuthView.swift; sourceTree = "<group>"; };
 		2BE65F4E27C39595005D370D /* RoomStartVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomStartVC.swift; sourceTree = "<group>"; };
 		2BE65F5027C3E34B005D370D /* RoomStart.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RoomStart.storyboard; sourceTree = "<group>"; };
+		2BE907DE27D9EE7D00B36002 /* NoticeAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAPI.swift; sourceTree = "<group>"; };
+		2BE907E027D9EE9700B36002 /* NoticeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeService.swift; sourceTree = "<group>"; };
 		2BEA121C27BA1CB400B67756 /* HabitRoomMemberCVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HabitRoomMemberCVC.swift; sourceTree = "<group>"; };
 		2BF3AB462794765F001A9042 /* RoomService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomService.swift; sourceTree = "<group>"; };
 		2BF3AB48279479B8001A9042 /* RoomAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomAPI.swift; sourceTree = "<group>"; };
@@ -579,6 +583,15 @@
 				EB9C509727931E4600588155 /* AuthUploadVC.swift */,
 			);
 			path = AuthUpload;
+			sourceTree = "<group>";
+		};
+		2BE907DD27D9EE6800B36002 /* Notice */ = {
+			isa = PBXGroup;
+			children = (
+				2BE907DE27D9EE7D00B36002 /* NoticeAPI.swift */,
+				2BE907E027D9EE9700B36002 /* NoticeService.swift */,
+			);
+			path = Notice;
 			sourceTree = "<group>";
 		};
 		2BF3AB42279475B9001A9042 /* Room */ = {
@@ -959,6 +972,7 @@
 			isa = PBXGroup;
 			children = (
 				F82F58052792897B003E4174 /* Plugin */,
+				2BE907DD27D9EE6800B36002 /* Notice */,
 				F8E3496627969B4F001B67E7 /* Auth */,
 				F82F5806279289AC003E4174 /* Home */,
 				2BF3AB42279475B9001A9042 /* Room */,
@@ -1388,6 +1402,7 @@
 				EBEA382F27947C9E00B5736A /* MyRoomService.swift in Sources */,
 				2B69E7E5278E22F4000F927F /* FeedHeaderView.swift in Sources */,
 				2BBED13527956EAB0052CA5C /* FeedAPI.swift in Sources */,
+				2BE907DF27D9EE7D00B36002 /* NoticeAPI.swift in Sources */,
 				F80A3E55278C1C1F00728E07 /* StorageVC.swift in Sources */,
 				F82F580C27929F74003E4174 /* Header.swift in Sources */,
 				EBA2D6D4279AB50D0022DFD6 /* ViewForRender.swift in Sources */,
@@ -1464,6 +1479,7 @@
 				F8E3496D2796B7F6001B67E7 /* Signup.swift in Sources */,
 				F8E3496A27969B67001B67E7 /* AuthService.swift in Sources */,
 				2BA98FB227CB44E800C53820 /* HabitRoomLeaveVC.swift in Sources */,
+				2BE907E127D9EE9700B36002 /* NoticeService.swift in Sources */,
 				F8096F3027841F9200B71D38 /* HomeVC.swift in Sources */,
 				F8250CFA27D25F2B0073FFCA /* UserService.swift in Sources */,
 				F82F5808279289B2003E4174 /* HomeAPI.swift in Sources */,

--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2B13FB23279899C6004CCE46 /* UIScreen+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B13FB22279899C6004CCE46 /* UIScreen+.swift */; };
 		2B13FB252798B705004CCE46 /* CompleteAuthVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C50892792A86D00588155 /* CompleteAuthVC.swift */; };
 		2B13FB262798B70A004CCE46 /* MyRoomCerti.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE90FCD2795C23A00157075 /* MyRoomCerti.swift */; };
+		2B2D31B827DA68EE000EDD28 /* ServiceNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2D31B727DA68EE000EDD28 /* ServiceNotice.swift */; };
 		2B50C1A227D7752C004BED9C /* NoticeActiveCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B50C1A127D7752C004BED9C /* NoticeActiveCVC.swift */; };
 		2B50C1A427D77CA9004BED9C /* NoticeServiceCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B50C1A327D77CA9004BED9C /* NoticeServiceCVC.swift */; };
 		2B54D01627D3B2810060DA06 /* FeedReportVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B54D01527D3B2810060DA06 /* FeedReportVC.swift */; };
@@ -188,6 +189,7 @@
 		2B014FAE27AAA90E004B4559 /* FeedFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedFooterView.swift; sourceTree = "<group>"; };
 		2B0CF77327BFEDAC003C2E21 /* BottomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButton.swift; sourceTree = "<group>"; };
 		2B13FB22279899C6004CCE46 /* UIScreen+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+.swift"; sourceTree = "<group>"; };
+		2B2D31B727DA68EE000EDD28 /* ServiceNotice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceNotice.swift; sourceTree = "<group>"; };
 		2B50C1A127D7752C004BED9C /* NoticeActiveCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeActiveCVC.swift; sourceTree = "<group>"; };
 		2B50C1A327D77CA9004BED9C /* NoticeServiceCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeServiceCVC.swift; sourceTree = "<group>"; };
 		2B54D01527D3B2810060DA06 /* FeedReportVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedReportVC.swift; sourceTree = "<group>"; };
@@ -600,6 +602,7 @@
 			isa = PBXGroup;
 			children = (
 				2BE907E327D9F1BB00B36002 /* ActiveNotice.swift */,
+				2B2D31B727DA68EE000EDD28 /* ServiceNotice.swift */,
 			);
 			path = Notice;
 			sourceTree = "<group>";
@@ -1437,6 +1440,7 @@
 				EBEA38372794B34300B5736A /* CodeJoinCheck.swift in Sources */,
 				F8096F2B27841F4100B71D38 /* Storyboard.swift in Sources */,
 				2B57F38127971D1D002A677D /* ProfileSettingVC.swift in Sources */,
+				2B2D31B827DA68EE000EDD28 /* ServiceNotice.swift in Sources */,
 				F8250CFC27D483E70073FFCA /* Profile.swift in Sources */,
 				2BC17270278F54DB00BA3029 /* WaitingVC.swift in Sources */,
 				EB874AEB279706FC000DD20B /* DialogueVC.swift in Sources */,

--- a/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeActiveCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeActiveCVC.swift
@@ -33,6 +33,7 @@ class NoticeActiveCVC: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        self.backgroundColor = .clear
         titleLabel.text = ""
         contentLabel.text = ""
         dateLabel.text = ""

--- a/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeActiveCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeActiveCVC.swift
@@ -62,7 +62,7 @@ class NoticeActiveCVC: UICollectionViewCell {
         bottomLineView.backgroundColor = .sparkGray.withAlphaComponent(0.3)
     }
     
-    func initCell(title: String, content: String, date: String, image: String, isThumbProfile: Bool, newService: Bool) {
+    func initCell(title: String, content: String, date: String, image: String, isThumbProfile: Bool, isNew: Bool) {
         titleLabel.text = title
         contentLabel.text = content
         dateLabel.text = date
@@ -74,7 +74,7 @@ class NoticeActiveCVC: UICollectionViewCell {
             contentImageView.layer.cornerRadius = 2
         }
         
-        if newService {
+        if isNew {
             self.backgroundColor = .sparkMostLightPinkred.withAlphaComponent(0.3)
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeActiveCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeActiveCVC.swift
@@ -54,20 +54,28 @@ class NoticeActiveCVC: UICollectionViewCell {
         contentLabel.numberOfLines = 2
         
         contentImageView.layer.borderWidth = 2
-        contentImageView.layer.borderColor = UIColor.sparkWhite.cgColor
+        contentImageView.layer.borderColor = UIColor.sparkLightGray.cgColor
         contentImageView.layer.masksToBounds = true
         contentImageView.contentMode = .scaleAspectFill
-        contentImageView.backgroundColor = .sparkDarkGray
         
         bottomLineView.backgroundColor = .sparkGray.withAlphaComponent(0.3)
     }
     
-    func initCell(title: String, content: String, date: String, image: String) {
-        // TODO: - 사진 종류에 따라 radius 적용
+    func initCell(title: String, content: String, date: String, image: String, isThumbProfile: Bool, newService: Bool) {
         titleLabel.text = title
         contentLabel.text = content
         dateLabel.text = date
         contentImageView.updateImage(image, type: .small)
+        
+        if isThumbProfile {
+            contentImageView.layer.cornerRadius = 20
+        } else {
+            contentImageView.layer.cornerRadius = 2
+        }
+        
+        if newService {
+            self.backgroundColor = .sparkMostLightPinkred.withAlphaComponent(0.3)
+        }
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeServiceCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeServiceCVC.swift
@@ -54,10 +54,14 @@ class NoticeServiceCVC: UICollectionViewCell {
         bottomLineView.backgroundColor = .sparkGray.withAlphaComponent(0.3)
     }
     
-    func initCell(title: String, content: String, date: String) {
+    func initCell(title: String, content: String, date: String, isNew: Bool) {
         titleLabel.text = title
         contentLabel.text = content
         dateLabel.text = date
+        
+        if isNew {
+            self.backgroundColor = .sparkMostLightPinkred.withAlphaComponent(0.3)
+        }
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeServiceCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Notice/NoticeServiceCVC.swift
@@ -32,6 +32,7 @@ class NoticeServiceCVC: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        self.backgroundColor = .clear
         titleLabel.text = ""
         contentLabel.text = ""
         dateLabel.text = ""

--- a/Spark-iOS/Spark-iOS/Source/NetworkModels/Notice/ActiveNotice.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkModels/Notice/ActiveNotice.swift
@@ -1,0 +1,29 @@
+//
+//  ActiveNotice.swift
+//  Spark-iOS
+//
+//  Created by 양수빈 on 2022/03/10.
+//
+
+import Foundation
+
+// MARK: - ActiveNotice
+struct ActiveNotice: Codable {
+    let newService: Bool
+    let notices: [Active]
+}
+
+// MARK: - Active
+struct Active: Codable {
+    let noticeID: Int
+    let noticeTitle, noticeContent: String
+    let noticeImg: String
+    let isThumbProfile: Bool
+    let day: String
+    let isNew: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case noticeID = "noticeId"
+        case noticeTitle, noticeContent, noticeImg, isThumbProfile, day, isNew
+    }
+}

--- a/Spark-iOS/Spark-iOS/Source/NetworkModels/Notice/ServiceNotice.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkModels/Notice/ServiceNotice.swift
@@ -1,0 +1,28 @@
+//
+//  ServiceNotice.swift
+//  Spark-iOS
+//
+//  Created by 양수빈 on 2022/03/11.
+//
+
+import Foundation
+
+// MARK: - DataClass
+struct ServiceNotice: Codable {
+    let newActive: Bool
+    let notices: [Service]
+}
+
+// MARK: - Notice
+struct Service: Codable {
+    let noticeID: Int
+    let noticeTitle: String
+    let noticeContent: String
+    let day: String
+    let isNew: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case noticeID = "noticeId"
+        case noticeTitle, noticeContent, day, isNew
+    }
+}

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
@@ -87,4 +87,34 @@ public class NoticeAPI {
             return .networkFail
         }
     }
+    
+    func activeRead(completion: @escaping(NetworkResult<Any>) -> Void) {
+        noticeProvider.request(.activeRead) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<String>.self, from: data)
+        else { return .pathErr }
+        switch statusCode {
+        case 200:
+            return .success(decodedData.message)
+        case 400..<500:
+            return .requestErr(decodedData.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
@@ -1,0 +1,8 @@
+//
+//  NoticeAPI.swift
+//  Spark-iOS
+//
+//  Created by 양수빈 on 2022/03/10.
+//
+
+import Foundation

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
@@ -6,3 +6,17 @@
 //
 
 import Foundation
+
+import Moya
+
+public class NoticeAPI {
+    
+    static let shared = NoticeAPI()
+    var noticeProvider = MoyaProvider<NoticeService>(plugins: [MoyaLoggerPlugin()])
+    
+    public init() { }
+    
+//    func activeFetch(lastID: Int, size: Int, completion: @escaping(NetworkResult<Any>) -> Void) {
+//
+//    }
+}

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
@@ -14,7 +14,7 @@ public class NoticeAPI {
     static let shared = NoticeAPI()
     var noticeProvider = MoyaProvider<NoticeService>(plugins: [MoyaLoggerPlugin()])
     
-    public init() { }
+    private init() { }
     
     func activeFetch(lastID: Int, size: Int, completion: @escaping(NetworkResult<Any>) -> Void) {
         noticeProvider.request(.activeFetch(lastID: lastID, size: size)) { result in

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
@@ -102,6 +102,20 @@ public class NoticeAPI {
         }
     }
     
+    func serviceRead(completion: @escaping(NetworkResult<Any>) -> Void) {
+        noticeProvider.request(.serviceRead) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
     private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
         let decoder = JSONDecoder()
         guard let decodedData = try? decoder.decode(GenericResponse<String>.self, from: data)

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
@@ -16,7 +16,39 @@ public class NoticeAPI {
     
     public init() { }
     
-//    func activeFetch(lastID: Int, size: Int, completion: @escaping(NetworkResult<Any>) -> Void) {
-//
-//    }
+    func activeFetch(lastID: Int, size: Int, completion: @escaping(NetworkResult<Any>) -> Void) {
+        noticeProvider.request(.activeFetch(lastID: lastID, size: size)) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                let networkResult = self.judgeActiveFetchStatus(by: statusCode, data)
+                completion(networkResult)
+                
+            case . failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    private func judgeActiveFetchStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<ActiveNotice>.self, from: data)
+        else {
+            return .pathErr
+        }
+        
+        switch statusCode {
+        case 200:
+            return .success(decodedData.data ?? "None-Data")
+        case 400..<500:
+            return .requestErr(decodedData.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
@@ -12,6 +12,7 @@ import Moya
 enum NoticeService {
     case activeFetch(lastID: Int, size: Int)
     case serviceFetch(lastID: Int, size: Int)
+    case activeRead
 }
 
 extension NoticeService: TargetType {
@@ -25,6 +26,8 @@ extension NoticeService: TargetType {
             return "/notice/active"
         case .serviceFetch:
             return "/notice/service"
+        case .activeRead:
+            return "/notice/active/read"
         }
     }
     
@@ -34,6 +37,8 @@ extension NoticeService: TargetType {
             return .get
         case .serviceFetch:
             return .get
+        case .activeRead:
+            return .patch
         }
     }
     
@@ -47,6 +52,8 @@ extension NoticeService: TargetType {
             return .requestParameters(parameters: ["lastId": lastID,
                                                    "size": size],
                                       encoding: URLEncoding.queryString)
+        case .activeRead:
+            return .requestPlain
         }
     }
     
@@ -55,6 +62,8 @@ extension NoticeService: TargetType {
         case .activeFetch:
             return Const.Header.authorizationHeader
         case .serviceFetch:
+            return Const.Header.authorizationHeader
+        case .activeRead:
             return Const.Header.authorizationHeader
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
@@ -50,7 +50,7 @@ extension NoticeService: TargetType {
         }
     }
     
-    var headers: [String : String]? {
+    var headers: [String: String]? {
         switch self {
         case .activeFetch:
             return Const.Header.authorizationHeader

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
@@ -13,6 +13,7 @@ enum NoticeService {
     case activeFetch(lastID: Int, size: Int)
     case serviceFetch(lastID: Int, size: Int)
     case activeRead
+    case serviceRead
 }
 
 extension NoticeService: TargetType {
@@ -28,6 +29,8 @@ extension NoticeService: TargetType {
             return "/notice/service"
         case .activeRead:
             return "/notice/active/read"
+        case .serviceRead:
+            return "/notice/service/read"
         }
     }
     
@@ -38,6 +41,8 @@ extension NoticeService: TargetType {
         case .serviceFetch:
             return .get
         case .activeRead:
+            return .patch
+        case .serviceRead:
             return .patch
         }
     }
@@ -54,6 +59,8 @@ extension NoticeService: TargetType {
                                       encoding: URLEncoding.queryString)
         case .activeRead:
             return .requestPlain
+        case .serviceRead:
+            return .requestPlain
         }
     }
     
@@ -64,6 +71,8 @@ extension NoticeService: TargetType {
         case .serviceFetch:
             return Const.Header.authorizationHeader
         case .activeRead:
+            return Const.Header.authorizationHeader
+        case .serviceRead:
             return Const.Header.authorizationHeader
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
@@ -1,0 +1,61 @@
+//
+//  NoticeService.swift
+//  Spark-iOS
+//
+//  Created by 양수빈 on 2022/03/10.
+//
+
+import Foundation
+
+import Moya
+
+enum NoticeService {
+    case activeFetch(lastID: Int, size: Int)
+    case serviceFetch(lastID: Int, size: Int)
+}
+
+extension NoticeService: TargetType {
+    var baseURL: URL {
+        return URL(string: Const.URL.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .activeFetch:
+            return "/notice/active"
+        case .serviceFetch:
+            return "/notice/service"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .activeFetch:
+            return .get
+        case .serviceFetch:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .activeFetch(lastID: let lastID, size: let size):
+            return .requestParameters(parameters: ["lastId": lastID,
+                                                   "size": size],
+                                      encoding: URLEncoding.queryString)
+        case .serviceFetch(lastID: let lastID, size: let size):
+            return .requestParameters(parameters: ["lastId": lastID,
+                                                   "size": size],
+                                      encoding: URLEncoding.queryString)
+        }
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+        case .activeFetch:
+            return Const.Header.authorizationHeader
+        case .serviceFetch:
+            return Const.Header.authorizationHeader
+        }
+    }
+}

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -16,6 +16,7 @@ class NoticeVC: UIViewController {
     private let headerView = UIView()
     private let activeButton = UIButton() // 스파커 활동
     private let noticeButton = UIButton() // 안내
+    private let activeBadgeView = UIView()
     private let noticeBadgeView = UIView()
     private let emptyView = UIView()
     private let emptyImageView = UIImageView()
@@ -97,6 +98,10 @@ class NoticeVC: UIViewController {
         
         noticeBadgeView.backgroundColor = .sparkDarkPinkred
         noticeBadgeView.layer.cornerRadius = 3
+        
+        activeBadgeView.backgroundColor = .sparkDarkPinkred
+        activeBadgeView.layer.cornerRadius = 3
+        activeBadgeView.isHidden = true
     }
     
     private func setEmptyView() {
@@ -163,6 +168,7 @@ class NoticeVC: UIViewController {
     private func touchActiveButton() {
         activeButton.isSelected = true
         noticeButton.isSelected = false
+        activeBadgeView.isHidden = true
         makeDrawAboveButton(button: activeButton)
         
         isActivity = true
@@ -187,6 +193,7 @@ class NoticeVC: UIViewController {
     private func touchNoticeButton() {
         activeButton.isSelected = false
         noticeButton.isSelected = true
+        noticeBadgeView.isHidden = true
         makeDrawAboveButton(button: noticeButton)
         
         isActivity = false
@@ -198,12 +205,11 @@ class NoticeVC: UIViewController {
                 self.emptyView.isHidden = false
             }
             
-            // TODO: - 스파커 활동 위에 뱃지 추가하고 isHidden 처리
-//            if self.newActive {
-//
-//            } else {
-//
-//            }
+            if self.newActive {
+                self.activeBadgeView.isHidden = false
+            } else {
+                self.activeBadgeView.isHidden = true
+            }
         }
         collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
     }
@@ -353,7 +359,7 @@ extension NoticeVC {
 extension NoticeVC {
     private func setLayout() {
         view.addSubviews([customNavigationBar, headerView, collectionView, emptyView])
-        headerView.addSubviews([activeButton, noticeButton, noticeBadgeView])
+        headerView.addSubviews([activeButton, noticeButton, noticeBadgeView, activeBadgeView])
         emptyView.addSubviews([emptyImageView, emptyLabel])
         
         customNavigationBar.snp.makeConstraints { make in
@@ -387,6 +393,12 @@ extension NoticeVC {
             make.width.height.equalTo(6)
             make.bottom.equalTo(noticeButton.snp.top).offset(12)
             make.leading.equalTo(noticeButton.snp.trailing)
+        }
+        
+        activeBadgeView.snp.makeConstraints { make in
+            make.width.height.equalTo(6)
+            make.bottom.equalTo(activeButton.snp.top).offset(12)
+            make.leading.equalTo(activeButton.snp.trailing)
         }
         
         emptyView.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -99,6 +99,7 @@ class NoticeVC: UIViewController {
         
         noticeBadgeView.backgroundColor = .sparkDarkPinkred
         noticeBadgeView.layer.cornerRadius = 3
+        noticeBadgeView.isHidden = true
         
         activeBadgeView.backgroundColor = .sparkDarkPinkred
         activeBadgeView.layer.cornerRadius = 3
@@ -187,6 +188,7 @@ class NoticeVC: UIViewController {
                 self.noticeBadgeView.isHidden = true
             }
             self.activeReadWithAPI()
+            self.collectionView.reloadData()
         }
         collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
     }
@@ -212,6 +214,8 @@ class NoticeVC: UIViewController {
             } else {
                 self.activeBadgeView.isHidden = true
             }
+            self.serviceReadWithAPI()
+            self.collectionView.reloadData()
         }
         collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
     }
@@ -361,13 +365,30 @@ extension NoticeVC {
             case .success(let message):
                 print("activeReadWithAPI - success: \(message)")
             case .requestErr(let message):
-                print("setPurposeWithAPI - requestErr: \(message)")
+                print("activeReadWithAPI - requestErr: \(message)")
             case .pathErr:
-                print("setPurposeWithAPI - pathErr")
+                print("activeReadWithAPI - pathErr")
             case .serverErr:
-                print("setPurposeWithAPI - serverErr")
+                print("activeReadWithAPI - serverErr")
             case .networkFail:
-                print("setPurposeWithAPI - networkFail")
+                print("activeReadWithAPI - networkFail")
+            }
+        }
+    }
+    
+    func serviceReadWithAPI() {
+        NoticeAPI.shared.serviceRead { response in
+            switch response {
+            case .success(let message):
+                print("serviceReadWithAPI - success: \(message)")
+            case .requestErr(let message):
+                print("serviceReadWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("serviceReadWithAPI - pathErr")
+            case .serverErr:
+                print("serviceReadWithAPI - serverErr")
+            case .networkFail:
+                print("serviceReadWithAPI - networkFail")
             }
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -25,11 +25,16 @@ class NoticeVC: UIViewController {
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
     private var customNavigationBar = LeftButtonNavigaitonBar()
     private var isActivity: Bool = true
+    private var activeLastID: Int = -1
+    private var activeCountSize: Int = 10
+    
+    private var activeList: [Active] = []
+    private var newNotice: Bool = false
     
     // MARK: - DummyData
     
-    let titleList = ["방방방방방방방방방방방방방방방방에서 보낸 스파크", "가나다라마바사아자차카타파하가님이 좋아한 피드", "세은님 고민중..💭", "아침 독서방 인원 변동 🚨", "센님의 인증 완료!", "가나다라마바사아자차카타파하가님이 좋아한 피드", "세은님 고민중..💭", "아침 독서방 인원 변동 🚨", "센님의 인증 완료!"]
-    let contentList = ["수아 : 💬 가나다라마바사아자차카타파하가", "가나다라마바사아자차카타파하가방 인증을 좋아해요.", "10분 독서, 오늘 좀 힘든걸? 스파크 plz", "가나다라마바사아자차카타파님이 습관방에서 나갔어요.", "10분 독서방 인증을 완료했어요.", "가나다라마바사아자차카타파하가방 인증을 좋아해요.", "10분 독서, 오늘 좀 힘든걸? 스파크 plz", "가나다라마바사아자차카타파님이 습관방에서 나갔어요.", "10분 독서방 인증을 완료했어요."]
+//    let titleList = ["방방방방방방방방방방방방방방방방에서 보낸 스파크", "가나다라마바사아자차카타파하가님이 좋아한 피드", "세은님 고민중..💭", "아침 독서방 인원 변동 🚨", "센님의 인증 완료!", "가나다라마바사아자차카타파하가님이 좋아한 피드", "세은님 고민중..💭", "아침 독서방 인원 변동 🚨", "센님의 인증 완료!"]
+//    let contentList = ["수아 : 💬 가나다라마바사아자차카타파하가", "가나다라마바사아자차카타파하가방 인증을 좋아해요.", "10분 독서, 오늘 좀 힘든걸? 스파크 plz", "가나다라마바사아자차카타파님이 습관방에서 나갔어요.", "10분 독서방 인증을 완료했어요.", "가나다라마바사아자차카타파하가방 인증을 좋아해요.", "10분 독서, 오늘 좀 힘든걸? 스파크 plz", "가나다라마바사아자차카타파님이 습관방에서 나갔어요.", "10분 독서방 인증을 완료했어요."]
     
     let secondTitleList = ["새로운 습관 시작 🔥", "가나다라마바사아자차카타파하가 대기방 삭제"]
     let secontContentList = ["가나다라마바사아자차카타파하방에서 가장 먼저 스파크를 보내볼까요?", "방 개설자에 의해 대기방이 삭제되었어요."]
@@ -47,6 +52,21 @@ class NoticeVC: UIViewController {
         
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
             self.makeDrawAboveButton(button: self.activeButton)
+        }
+        
+        getActiveNoticeFetchWithAPI(lastID: activeLastID) {
+            if self.activeList.isEmpty {
+                self.emptyView.isHidden = true
+            } else {
+                self.emptyView.isHidden = false
+                self.collectionView.reloadData()
+            }
+            
+            if self.newNotice {
+                self.noticeBadgeView.isHidden = false
+            } else {
+                self.noticeBadgeView.isHidden = true
+            }
         }
     }
     
@@ -179,7 +199,7 @@ extension NoticeVC: UICollectionViewDelegate {
 extension NoticeVC: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if isActivity {
-            return titleList.count
+            return activeList.count
         } else {
             return secondTitleList.count
         }
@@ -189,7 +209,7 @@ extension NoticeVC: UICollectionViewDataSource {
         if isActivity {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.noticeActiveCVC, for: indexPath) as? NoticeActiveCVC else { return UICollectionViewCell() }
             
-            cell.initCell(title: titleList[indexPath.row], content: contentList[indexPath.row], date: "오늘", image: "")
+            cell.initCell(title: activeList[indexPath.item].noticeTitle, content: activeList[indexPath.item].noticeContent, date: activeList[indexPath.item].day, image: activeList[indexPath.item].noticeImg, isThumbProfile: activeList[indexPath.item].isThumbProfile, newService: activeList[indexPath.item].isNew)
             
             return cell
         } else {
@@ -210,7 +230,7 @@ extension NoticeVC: UICollectionViewDelegateFlowLayout {
         if isActivity {
             let dummyCell = NoticeActiveCVC(frame: CGRect(x: 0, y: 0, width: width, height: estimatedHeight))
             
-            dummyCell.initCell(title: titleList[indexPath.row], content: contentList[indexPath.row], date: "오늘", image: "")
+            dummyCell.initCell(title: activeList[indexPath.item].noticeTitle, content: activeList[indexPath.item].noticeContent, date: activeList[indexPath.item].day, image: activeList[indexPath.item].noticeImg, isThumbProfile: activeList[indexPath.item].isThumbProfile, newService: activeList[indexPath.item].isNew)
             dummyCell.layoutIfNeeded()
             
             let estimatedSize = dummyCell.systemLayoutSizeFitting(CGSize(width: width, height: estimatedHeight))
@@ -238,6 +258,29 @@ extension NoticeVC: UICollectionViewDelegateFlowLayout {
 }
 
 // MARK: - Network
+
+extension NoticeVC {
+    private func getActiveNoticeFetchWithAPI(lastID: Int, completion: @escaping() -> Void) {
+        NoticeAPI.shared.activeFetch(lastID: lastID, size: activeCountSize) { response in
+            switch response {
+            case .success(let data):
+                if let active = data as? ActiveNotice {
+                    self.newNotice = active.newService
+                    self.activeList.append(contentsOf: active.notices)
+                }
+                completion()
+            case .requestErr(let message):
+                print("getActiveNoticeFetchWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("getActiveNoticeFetchWithAPI - pathErr")
+            case .serverErr:
+                print("getActiveNoticeFetchWithAPI - serverErr")
+            case .networkFail:
+                print("getActiveNoticeFetchWithAPI - networkFail")
+            }
+        }
+    }
+}
 
 // MARK: - Layout
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -25,20 +25,16 @@ class NoticeVC: UIViewController {
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
     private var customNavigationBar = LeftButtonNavigaitonBar()
     private var isActivity: Bool = true
+    private var isInfiniteScroll: Bool = true
     private var activeLastID: Int = -1
     private var activeCountSize: Int = 10
-    private var isInfiniteScroll: Bool = true
+    private var serviceLastID: Int = -1
+    private var serviceCountSize: Int = 10
     
     private var activeList: [Active] = []
-    private var newNotice: Bool = false
-    
-    // MARK: - DummyData
-    
-//    let titleList = ["방방방방방방방방방방방방방방방방에서 보낸 스파크", "가나다라마바사아자차카타파하가님이 좋아한 피드", "세은님 고민중..💭", "아침 독서방 인원 변동 🚨", "센님의 인증 완료!", "가나다라마바사아자차카타파하가님이 좋아한 피드", "세은님 고민중..💭", "아침 독서방 인원 변동 🚨", "센님의 인증 완료!"]
-//    let contentList = ["수아 : 💬 가나다라마바사아자차카타파하가", "가나다라마바사아자차카타파하가방 인증을 좋아해요.", "10분 독서, 오늘 좀 힘든걸? 스파크 plz", "가나다라마바사아자차카타파님이 습관방에서 나갔어요.", "10분 독서방 인증을 완료했어요.", "가나다라마바사아자차카타파하가방 인증을 좋아해요.", "10분 독서, 오늘 좀 힘든걸? 스파크 plz", "가나다라마바사아자차카타파님이 습관방에서 나갔어요.", "10분 독서방 인증을 완료했어요."]
-    
-    let secondTitleList = ["새로운 습관 시작 🔥", "가나다라마바사아자차카타파하가 대기방 삭제"]
-    let secontContentList = ["가나다라마바사아자차카타파하방에서 가장 먼저 스파크를 보내볼까요?", "방 개설자에 의해 대기방이 삭제되었어요."]
+    private var serviceList: [Service] = []
+    private var newService: Bool = false
+    private var newActive: Bool = false
     
     // MARK: - View Life Cycles
 
@@ -62,7 +58,7 @@ class NoticeVC: UIViewController {
                 self.emptyView.isHidden = false
             }
             
-            if self.newNotice {
+            if self.newService {
                 self.noticeBadgeView.isHidden = false
             } else {
                 self.noticeBadgeView.isHidden = true
@@ -178,7 +174,7 @@ class NoticeVC: UIViewController {
                 self.emptyView.isHidden = false
             }
             
-            if self.newNotice {
+            if self.newService {
                 self.noticeBadgeView.isHidden = false
             } else {
                 self.noticeBadgeView.isHidden = true
@@ -194,7 +190,21 @@ class NoticeVC: UIViewController {
         makeDrawAboveButton(button: noticeButton)
         
         isActivity = false
-        collectionView.reloadData()
+        serviceLastID = -1
+        getServiceNoticeFetchWithAPI(lastID: serviceLastID) {
+            if self.serviceList.isEmpty {
+                self.emptyView.isHidden = true
+            } else {
+                self.emptyView.isHidden = false
+            }
+            
+            // TODO: - 스파커 활동 위에 뱃지 추가하고 isHidden 처리
+//            if self.newActive {
+//
+//            } else {
+//
+//            }
+        }
         collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
     }
 }
@@ -211,9 +221,16 @@ extension NoticeVC: UICollectionViewDelegate {
             if isInfiniteScroll {
                 isInfiniteScroll = false
                 
-                activeLastID = activeList.last?.noticeID ?? 0
-                getActiveNoticeFetchWithAPI(lastID: activeLastID) {
-                    self.isInfiniteScroll = true
+                if isActivity {
+                    activeLastID = activeList.last?.noticeID ?? 0
+                    getActiveNoticeFetchWithAPI(lastID: activeLastID) {
+                        self.isInfiniteScroll = true
+                    }
+                } else {
+                    serviceLastID = serviceList.last?.noticeID ?? 0
+                    getServiceNoticeFetchWithAPI(lastID: serviceLastID) {
+                        self.isInfiniteScroll = true
+                    }
                 }
             }
         }
@@ -227,7 +244,7 @@ extension NoticeVC: UICollectionViewDataSource {
         if isActivity {
             return activeList.count
         } else {
-            return secondTitleList.count
+            return serviceList.count
         }
     }
 
@@ -241,7 +258,7 @@ extension NoticeVC: UICollectionViewDataSource {
         } else {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.noticeServiceCVC, for: indexPath) as? NoticeServiceCVC else { return UICollectionViewCell() }
             
-            cell.initCell(title: secondTitleList[indexPath.row], content: secontContentList[indexPath.row], date: "1일 전")
+            cell.initCell(title: serviceList[indexPath.item].noticeTitle, content: serviceList[indexPath.item].noticeContent, date: serviceList[indexPath.item].day, isNew: serviceList[indexPath.item].isNew)
             
             return cell
         }
@@ -265,7 +282,7 @@ extension NoticeVC: UICollectionViewDelegateFlowLayout {
         } else {
             let dummyCell = NoticeServiceCVC(frame: CGRect(x: 0, y: 0, width: width, height: estimatedHeight))
             
-            dummyCell.initCell(title: secondTitleList[indexPath.row], content: secontContentList[indexPath.row], date: "1일 전")
+            dummyCell.initCell(title: serviceList[indexPath.item].noticeTitle, content: serviceList[indexPath.item].noticeContent, date: serviceList[indexPath.item].day, isNew: serviceList[indexPath.item].isNew)
             dummyCell.layoutIfNeeded()
             
             let estimatedSize = dummyCell.systemLayoutSizeFitting(CGSize(width: width, height: estimatedHeight))
@@ -291,7 +308,7 @@ extension NoticeVC {
             switch response {
             case .success(let data):
                 if let active = data as? ActiveNotice {
-                    self.newNotice = active.newService
+                    self.newService = active.newService
                     self.activeList.append(contentsOf: active.notices)
                     self.collectionView.reloadData()
                 }
@@ -304,6 +321,28 @@ extension NoticeVC {
                 print("getActiveNoticeFetchWithAPI - serverErr")
             case .networkFail:
                 print("getActiveNoticeFetchWithAPI - networkFail")
+            }
+        }
+    }
+    
+    private func getServiceNoticeFetchWithAPI(lastID: Int, completion: @escaping() -> Void) {
+        NoticeAPI.shared.serviceFetch(lastID: lastID, size: serviceCountSize) { response in
+            switch response {
+            case .success(let data):
+                if let service = data as? ServiceNotice {
+                    self.newActive = service.newActive
+                    self.serviceList.append(contentsOf: service.notices)
+                    self.collectionView.reloadData()
+                }
+                completion()
+            case .requestErr(let message):
+                print("getServiceNoticeFetchWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("getServiceNoticeFetchWithAPI - pathErr")
+            case .serverErr:
+                print("getServiceNoticeFetchWithAPI - serverErr")
+            case .networkFail:
+                print("getServiceNoticeFetchWithAPI - networkFail")
             }
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -64,6 +64,7 @@ class NoticeVC: UIViewController {
             } else {
                 self.noticeBadgeView.isHidden = true
             }
+            self.activeReadWithAPI()
         }
     }
     
@@ -185,6 +186,7 @@ class NoticeVC: UIViewController {
             } else {
                 self.noticeBadgeView.isHidden = true
             }
+            self.activeReadWithAPI()
         }
         collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
     }
@@ -349,6 +351,23 @@ extension NoticeVC {
                 print("getServiceNoticeFetchWithAPI - serverErr")
             case .networkFail:
                 print("getServiceNoticeFetchWithAPI - networkFail")
+            }
+        }
+    }
+    
+    func activeReadWithAPI() {
+        NoticeAPI.shared.activeRead { response in
+            switch response {
+            case .success(let message):
+                print("activeReadWithAPI - success: \(message)")
+            case .requestErr(let message):
+                print("setPurposeWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("setPurposeWithAPI - pathErr")
+            case .serverErr:
+                print("setPurposeWithAPI - serverErr")
+            case .networkFail:
+                print("setPurposeWithAPI - networkFail")
             }
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -15,9 +15,9 @@ class NoticeVC: UIViewController {
     
     private let headerView = UIView()
     private let activeButton = UIButton() // 스파커 활동
-    private let noticeButton = UIButton() // 안내
+    private let serviceButton = UIButton() // 안내
     private let activeBadgeView = UIView()
-    private let noticeBadgeView = UIView()
+    private let serviceBadgeView = UIView()
     private let emptyView = UIView()
     private let emptyImageView = UIImageView()
     private let emptyLabel = UILabel()
@@ -60,9 +60,9 @@ class NoticeVC: UIViewController {
             }
             
             if self.newService {
-                self.noticeBadgeView.isHidden = false
+                self.serviceBadgeView.isHidden = false
             } else {
-                self.noticeBadgeView.isHidden = true
+                self.serviceBadgeView.isHidden = true
             }
             self.activeReadWithAPI()
         }
@@ -89,17 +89,17 @@ class NoticeVC: UIViewController {
         activeButton.titleLabel?.font = .h3Subtitle
         activeButton.isSelected = true
         
-        noticeButton.setTitle("안내", for: .normal)
-        noticeButton.setTitleColor(.sparkDarkPinkred, for: .selected)
-        noticeButton.setTitleColor(.sparkDarkGray, for: .normal)
-        noticeButton.titleLabel?.font = .h3Subtitle
+        serviceButton.setTitle("안내", for: .normal)
+        serviceButton.setTitleColor(.sparkDarkPinkred, for: .selected)
+        serviceButton.setTitleColor(.sparkDarkGray, for: .normal)
+        serviceButton.titleLabel?.font = .h3Subtitle
         
         activeButton.tag = 1
-        noticeButton.tag = 2
+        serviceButton.tag = 2
         
-        noticeBadgeView.backgroundColor = .sparkDarkPinkred
-        noticeBadgeView.layer.cornerRadius = 3
-        noticeBadgeView.isHidden = true
+        serviceBadgeView.backgroundColor = .sparkDarkPinkred
+        serviceBadgeView.layer.cornerRadius = 3
+        serviceBadgeView.isHidden = true
         
         activeBadgeView.backgroundColor = .sparkDarkPinkred
         activeBadgeView.layer.cornerRadius = 3
@@ -133,7 +133,7 @@ class NoticeVC: UIViewController {
     
     private func setAddTarget() {
         activeButton.addTarget(self, action: #selector(touchActiveButton), for: .touchUpInside)
-        noticeButton.addTarget(self, action: #selector(touchNoticeButton), for: .touchUpInside)
+        serviceButton.addTarget(self, action: #selector(touchNoticeButton), for: .touchUpInside)
     }
 
     private func popToHomeVC() {
@@ -169,7 +169,7 @@ class NoticeVC: UIViewController {
     @objc
     private func touchActiveButton() {
         activeButton.isSelected = true
-        noticeButton.isSelected = false
+        serviceButton.isSelected = false
         activeBadgeView.isHidden = true
         makeDrawAboveButton(button: activeButton)
         
@@ -183,12 +183,11 @@ class NoticeVC: UIViewController {
             }
             
             if self.newService {
-                self.noticeBadgeView.isHidden = false
+                self.serviceBadgeView.isHidden = false
             } else {
-                self.noticeBadgeView.isHidden = true
+                self.serviceBadgeView.isHidden = true
             }
             self.activeReadWithAPI()
-            self.collectionView.reloadData()
         }
         collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
     }
@@ -196,9 +195,9 @@ class NoticeVC: UIViewController {
     @objc
     private func touchNoticeButton() {
         activeButton.isSelected = false
-        noticeButton.isSelected = true
-        noticeBadgeView.isHidden = true
-        makeDrawAboveButton(button: noticeButton)
+        serviceButton.isSelected = true
+        serviceBadgeView.isHidden = true
+        makeDrawAboveButton(button: serviceButton)
         
         isActivity = false
         serviceLastID = -1
@@ -215,7 +214,6 @@ class NoticeVC: UIViewController {
                 self.activeBadgeView.isHidden = true
             }
             self.serviceReadWithAPI()
-            self.collectionView.reloadData()
         }
         collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
     }
@@ -399,7 +397,7 @@ extension NoticeVC {
 extension NoticeVC {
     private func setLayout() {
         view.addSubviews([customNavigationBar, headerView, collectionView, emptyView])
-        headerView.addSubviews([activeButton, noticeButton, noticeBadgeView, activeBadgeView])
+        headerView.addSubviews([activeButton, serviceButton, serviceBadgeView, activeBadgeView])
         emptyView.addSubviews([emptyImageView, emptyLabel])
         
         customNavigationBar.snp.makeConstraints { make in
@@ -424,15 +422,15 @@ extension NoticeVC {
             make.top.equalToSuperview().inset(26)
         }
         
-        noticeButton.snp.makeConstraints { make in
+        serviceButton.snp.makeConstraints { make in
             make.leading.equalTo(activeButton.snp.trailing).offset(32)
             make.centerY.equalTo(activeButton.snp.centerY)
         }
         
-        noticeBadgeView.snp.makeConstraints { make in
+        serviceBadgeView.snp.makeConstraints { make in
             make.width.height.equalTo(6)
-            make.bottom.equalTo(noticeButton.snp.top).offset(12)
-            make.leading.equalTo(noticeButton.snp.trailing)
+            make.bottom.equalTo(serviceButton.snp.top).offset(12)
+            make.leading.equalTo(serviceButton.snp.trailing)
         }
         
         activeBadgeView.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -196,7 +196,7 @@ class NoticeVC: UIViewController {
 
         group.notify(queue: .main) {
             self.activeReadWithAPI()
-            self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: true)
+            self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
         }
     }
     
@@ -230,7 +230,7 @@ class NoticeVC: UIViewController {
 
         group.notify(queue: .main) {
             self.serviceReadWithAPI()
-            self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: true)
+            self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
         }
     }
 }
@@ -280,7 +280,7 @@ extension NoticeVC: UICollectionViewDataSource {
         if isActivity {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.noticeActiveCVC, for: indexPath) as? NoticeActiveCVC else { return UICollectionViewCell() }
             
-            cell.initCell(title: activeList[indexPath.item].noticeTitle, content: activeList[indexPath.item].noticeContent, date: activeList[indexPath.item].day, image: activeList[indexPath.item].noticeImg, isThumbProfile: activeList[indexPath.item].isThumbProfile, newService: activeList[indexPath.item].isNew)
+            cell.initCell(title: activeList[indexPath.item].noticeTitle, content: activeList[indexPath.item].noticeContent, date: activeList[indexPath.item].day, image: activeList[indexPath.item].noticeImg, isThumbProfile: activeList[indexPath.item].isThumbProfile, isNew: activeList[indexPath.item].isNew)
             
             return cell
         } else {
@@ -301,7 +301,7 @@ extension NoticeVC: UICollectionViewDelegateFlowLayout {
         if isActivity {
             let dummyCell = NoticeActiveCVC(frame: CGRect(x: 0, y: 0, width: width, height: estimatedHeight))
             
-            dummyCell.initCell(title: activeList[indexPath.item].noticeTitle, content: activeList[indexPath.item].noticeContent, date: activeList[indexPath.item].day, image: activeList[indexPath.item].noticeImg, isThumbProfile: activeList[indexPath.item].isThumbProfile, newService: activeList[indexPath.item].isNew)
+            dummyCell.initCell(title: activeList[indexPath.item].noticeTitle, content: activeList[indexPath.item].noticeContent, date: activeList[indexPath.item].day, image: activeList[indexPath.item].noticeImg, isThumbProfile: activeList[indexPath.item].isThumbProfile, isNew: activeList[indexPath.item].isNew)
             dummyCell.layoutIfNeeded()
             
             let estimatedSize = dummyCell.systemLayoutSizeFitting(CGSize(width: width, height: estimatedHeight))


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#364

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- [x]  활동 알림 조회
- [x]  활동 알림 읽음 처리
- [x]  서비스 알림 조회
- [x]  서비스 알림 읽음 처리
- [x]  알림 조회 시, 빨콩 처리
- [x]  추가 UI 작업

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 하나의 컬렉션뷰를 사용하면서 전환하다보니 
스크롤한 뒤 전환하고 `scrollToTop`을 하면 `index` 에러가 떴습니당
- 실행 순서 문제일 것 같아서 `DispatchQueue`를 사용했는데, 작업이 끝난 뒤 실행되는 느낌이 아니라
좀 더 확실하다고.. 생각된 `DispatchGroup` 을 사용해서 한 작업을 끝나고 하도록 했습니다.. 맞겠죠?
- 일단 하긴 했는데 완벽하게 해결됐다고는 장담 못하겠습니다.. 나중에 QA 때 개선해야될 것 같습니다..

--
`scrollToTop`을 할 때 `animate`를 `true`로 할지 `false`로 할지 .. 뭐가 더 나을지 모르겠네욤 
아래 스크린샷 보시고 뭐가 더 나을지 의견 남겨주세용



## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
| animate `false` |<img src = "https://user-images.githubusercontent.com/81167570/157830681-9cd026b7-28aa-40c9-be84-e47a83bed5cd.gif" width ="250">|
| animate `true` |<img src = "https://user-images.githubusercontent.com/81167570/157830854-230c8527-da9a-41b7-ade4-b6fa2ac00656.gif" width ="250">|




## 📟 관련 이슈
- Resolved: #364 
