### PR TITLE
[Feat] #396 - 스파크사용가이드, 약관 및 정책 노션 인앱 연결

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Constants/URL.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/URL.swift
@@ -10,5 +10,8 @@ import Foundation
 extension Const {
     struct URL {
         static let baseURL = "https://asia-northeast3-we-sopt-spark.cloudfunctions.net/api"
+        // FIXME: - 현재 약관 및 정책 URL 로 설정됨.
+        static let sparkGuideURL = "https://jealous-supernova-274.notion.site/be178522025a4517a3a592fb85a49520"
+        static let tosURL = "https://jealous-supernova-274.notion.site/be178522025a4517a3a592fb85a49520"
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -6,7 +6,9 @@
 //
 
 import MessageUI
+import SafariServices
 import UIKit
+
 
 import SnapKit
 
@@ -151,7 +153,17 @@ extension MypageVC: UITableViewDelegate {
                 present(mailErrorAlert, animated: true, completion: nil)
             }
         case .service:
-            if indexPath.row == 3 {
+            if indexPath.row == 0 {
+                // 스파크 사용 가이드
+                guard let url = URL(string: Const.URL.sparkGuideURL) else { return }
+                let safariVC = SFSafariViewController(url: url)
+                present(safariVC, animated: true, completion: nil)
+            } else if indexPath.row == 1 {
+                // 약관 및 정책
+                guard let url = URL(string: Const.URL.tosURL) else { return }
+                let safariVC = SFSafariViewController(url: url)
+                present(safariVC, animated: true, completion: nil)
+            } else if indexPath.row == 3 {
                 // logout
                 guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
                 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -120,8 +120,6 @@ extension MypageVC: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // 선택시 회색으로 변했다가 돌아옴.
-        tableView.deselectRow(at: indexPath, animated: false)
         guard let section = MypageTableViewSection(rawValue: indexPath.section) else { return }
         switch section {
         case .profile:
@@ -143,7 +141,7 @@ extension MypageVC: UITableViewDelegate {
                 mailComposeVC.setSubject("스파크 문의 사항")
                 mailComposeVC.setMessageBody("문의 사항을 상세히 입력해주세요.",
                                              isHTML: false)
-                
+        
                 present(mailComposeVC, animated: true, completion: nil)
             } else {
                 // 메일이 계정과 연동되지 않은 경우.
@@ -157,11 +155,17 @@ extension MypageVC: UITableViewDelegate {
                 // 스파크 사용 가이드
                 guard let url = URL(string: Const.URL.sparkGuideURL) else { return }
                 let safariVC = SFSafariViewController(url: url)
+                safariVC.transitioningDelegate = self
+                safariVC.modalPresentationStyle = .pageSheet
+                
                 present(safariVC, animated: true, completion: nil)
             } else if indexPath.row == 1 {
                 // 약관 및 정책
                 guard let url = URL(string: Const.URL.tosURL) else { return }
                 let safariVC = SFSafariViewController(url: url)
+                safariVC.transitioningDelegate = self
+                safariVC.modalPresentationStyle = .pageSheet
+                
                 present(safariVC, animated: true, completion: nil)
             } else if indexPath.row == 3 {
                 // logout
@@ -225,39 +229,37 @@ extension MypageVC: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.section == 0 {
+        guard let section = MypageTableViewSection(rawValue: indexPath.section) else { return UITableViewCell() }
+        switch section {
+        case .profile:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: Const.Cell.Identifier.mypageProfileTVC, for: indexPath) as? MypageProfileTVC else { return UITableViewCell()}
             cell.initCell(profileImage: profileImage, nickname: profileNickname)
             cell.selectionStyle = .none
             
             return cell
-        } else if indexPath.section == 1 {
+        case .setting:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: Const.Cell.Identifier.mypageDefaultTVC, for: indexPath) as? MypageDefaultTVC else { return UITableViewCell()}
             cell.initCell(type: .notification)
             cell.selectionStyle = .none
             
             return cell
-        } else if indexPath.section == 2 {
+        case .center:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: Const.Cell.Identifier.mypageDefaultTVC, for: indexPath) as? MypageDefaultTVC else { return UITableViewCell()}
             cell.initCell(type: .contact)
             cell.selectionStyle = .none
             
             return cell
-        } else {
+        case .service:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: Const.Cell.Identifier.mypageDefaultTVC, for: indexPath) as? MypageDefaultTVC else { return UITableViewCell()}
             
             /*
-            MypageRow(rawValue: 3) 는 .sparkGuide 이다.
-            MypageRow(rawValue: 4) 는 .tos 이다.
-            MypageRow(rawValue: 6) 는 .logout 이다.
+             MypageRow(rawValue: 3) 는 .sparkGuide 이다.
+             MypageRow(rawValue: 4) 는 .tos 이다.
+             MypageRow(rawValue: 5) 는 .version 이다.
+             MypageRow(rawValue: 6) 는 .logout 이다.
              */
             guard let row = MypageRow(rawValue: indexPath.section + indexPath.row) else { return UITableViewCell() }
-                    cell.initCell(type: row)
-            
-            // MypageRow(rawValue: 5) 는 .version 이다.
-            if indexPath.row == 2 {
-                cell.isUserInteractionEnabled = false
-            }
+            cell.initCell(type: row)
             
             cell.selectionStyle = .none
             
@@ -328,6 +330,12 @@ extension MypageVC: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         controller.dismiss(animated: true, completion: nil)
     }
+}
+
+// MARK: - UIViewControllerTransitioningDelegate
+
+extension MypageVC: UIViewControllerTransitioningDelegate {
+    
 }
 
 // MARK: - UIGestureRecognizerDelegate

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -334,9 +334,7 @@ extension MypageVC: MFMailComposeViewControllerDelegate {
 
 // MARK: - UIViewControllerTransitioningDelegate
 
-extension MypageVC: UIViewControllerTransitioningDelegate {
-    
-}
+extension MypageVC: UIViewControllerTransitioningDelegate { }
 
 // MARK: - UIGestureRecognizerDelegate
 // FIXME: - 네비게이션 extension 정리후 공통으로 빼서 사용하기


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#396

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 스파크 사용 가이드 / 약관 및 정책 선택 시 인앱에서 사파리가 연결되도록 했습니다!
- 노션이 안열린다는 이슈를 염려했는데 그런거 없이 잘 열렸습니다! 아요는 해당하지 않나봐여
- 메일과 동일하게 인앱 느낌을 강하게 내기위해서 `modalPresentaionStyle` 을 `pageSheet` 으로 설정했습니다.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 기본적으로 사파리가 push 로 화면전환이 진행되요! 그런데 이 부분을 해결하기 위해서 `transitioningDelegate` 를 채택해서 본 뷰컨에서 다루어주는 방법으로 `modalPresentaionStyle` 을 적용했습니다!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|사파리 인앱연결|<img src = "https://user-images.githubusercontent.com/69136340/158583182-b0dfc061-29ad-48c8-b0fd-492c9dbad33b.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #396
