### PR TITLE
[Design] #410 - 홈 하단 inset 조절 및 커스텀 탭바에 맞추기

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Base.lproj/Home.storyboard
+++ b/Spark-iOS/Spark-iOS/Resource/Storyboards/TabBar/Base.lproj/Home.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -22,7 +22,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                             </imageView>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="RxS-om-6bn">
-                                <rect key="frame" x="0.0" y="104" width="414" height="758"/>
+                                <rect key="frame" x="0.0" y="104" width="414" height="704"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="NRt-6s-e02">
                                     <size key="itemSize" width="128" height="128"/>
@@ -59,7 +59,7 @@
                             <constraint firstAttribute="bottom" secondItem="Sqg-Wy-fj3" secondAttribute="bottom" id="ZIW-DD-9lc"/>
                             <constraint firstItem="Sqg-Wy-fj3" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="ZMj-YB-gq1"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="4LT-Mm-fKh" secondAttribute="trailing" id="e2g-Jw-pzo"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="RxS-om-6bn" secondAttribute="bottom" id="jbq-Db-2Qd"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="RxS-om-6bn" secondAttribute="bottom" constant="54" id="jbq-Db-2Qd"/>
                             <constraint firstItem="RxS-om-6bn" firstAttribute="top" secondItem="4LT-Mm-fKh" secondAttribute="bottom" id="lEH-ws-bEb"/>
                             <constraint firstItem="RxS-om-6bn" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="wMc-qe-enf"/>
                             <constraint firstItem="4LT-Mm-fKh" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="xKm-LC-i9O"/>

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -413,7 +413,7 @@ extension HomeVC: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20)
+        return UIEdgeInsets(top: 16, left: 20, bottom: 100, right: 20)
     }
 }
 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#410

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 커스텀 탭바의 위치는 안전영역위로 54 높이를 가지고있기때문에 홈 컬렉션뷰의 하단을 안전영역으로부터 54 잡아주었습니다.
- 플로팅 버튼이 티켓 생명을 가리기 때문에 하단 인셋이 늘어났고 제플린에서 확인해보니 100이기때문에 적용해주었습니다.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
다음을 참고했어요...
<img src="https://user-images.githubusercontent.com/69136340/159148907-b1ef8547-d942-46e4-a40b-2e1fccfa6f58.png" width ="500">

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|홈|<img src = "https://user-images.githubusercontent.com/69136340/159148900-1f8bc9d6-6126-4a3e-92a3-2d51534f71b0.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #410
