### PR TITLE
[Fix] #412 - 피드 레이아웃 및 isFirstScroll 조건 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -263,7 +263,8 @@ extension FeedVC {
         view.addSubviews([collectionView, emptyView])
         
         collectionView.snp.makeConstraints { make in
-            make.edges.equalTo(view.safeAreaLayoutGuide)
+            make.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(54)
         }
         
         emptyView.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -305,7 +305,7 @@ extension FeedVC {
                         self.isLastScroll = false
                     }
                     self.feedList.append(contentsOf: feed.records)
-                    if self.feedList.count > self.feedCountSize {
+                    if self.feedList.count >= self.feedCountSize {
                         self.isFirstScroll = false
                     }
                     self.setData(datalist: feed.records)


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#412



👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- collectionView 하단 레이아웃 수정
- isFirstScroll 조건 수정


## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
`self.feedList.count > self.feedCountSize`
이럴 경우, 피드가 많은 경우 첫번쨰 footer에서 isFirstScroll이 true라서 
footer에 그 마지막 멘트가 뜨게 됩니다.
그래서 feedList.count가 feedCountSize와 같을때도 isFirstScroll 을 false로 하도록 했슴니다

... 말이 정리가 안되네여 긁적..



## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #412 #414 
