### PR TITLE
[Feat] #418 - 마이페이지 오픈소스 라이브러리 노션 인앱 연결

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Constants/URL.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/URL.swift
@@ -13,5 +13,6 @@ extension Const {
         // FIXME: - 현재 약관 및 정책 URL 로 설정됨.
         static let sparkGuideURL = "https://jealous-supernova-274.notion.site/be178522025a4517a3a592fb85a49520"
         static let tosURL = "https://jealous-supernova-274.notion.site/be178522025a4517a3a592fb85a49520"
+        static let openSourceLibraryURL = "https://jealous-supernova-274.notion.site/Spark-Open-Source-Library-46ceed0477dc463ca9b8b3081a1370dc"
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Cells/Mypage/MypageDefaultTVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Mypage/MypageDefaultTVC.swift
@@ -95,6 +95,12 @@ extension MypageDefaultTVC {
             arrowImageView.isHidden = false
             versionLabel.isHidden = true
             withdrawalButton.isHidden = true
+        case .openSourceLibrary:
+            titleLabel.text = "오픈소스 라이브러리"
+            titleLabel.isHidden = false
+            arrowImageView.isHidden = false
+            versionLabel.isHidden = true
+            withdrawalButton.isHidden = true
         case .version:
             titleLabel.text = "버전 정보"
             titleLabel.isHidden = false

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -19,6 +19,7 @@ public enum MypageRow: Int {
     case contact // 문의하기
     case sparkGuide // 스파크 사용 가이드
     case tos // Terms of service terms of use. 약관 및 정책
+    case openSourceLibrary // 오픈소스 라이브러리
     case version // 버전 정보
     case logout // 로그아웃
     case withdrawal // 회원 탈퇴
@@ -191,6 +192,14 @@ extension MypageVC: UITableViewDelegate {
                 safariVC.modalPresentationStyle = .pageSheet
                 
                 present(safariVC, animated: true, completion: nil)
+            } else if indexPath.row == 2 {
+                // 오픈소스 라이브러리
+                guard let url = URL(string: Const.URL.openSourceLibraryURL) else { return }
+                let safariVC = SFSafariViewController(url: url)
+                safariVC.transitioningDelegate = self
+                safariVC.modalPresentationStyle = .pageSheet
+                
+                present(safariVC, animated: true, completion: nil)
             } else if indexPath.row == 3 {
                 // logout
                 guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
@@ -246,7 +255,7 @@ extension MypageVC: UITableViewDataSource {
             
             return rowOfSection.count
         case .service:
-            rowOfSection = [.sparkGuide, .tos, .version, .logout, .withdrawal]
+            rowOfSection = [.sparkGuide, .tos, .openSourceLibrary, .version, .logout, .withdrawal]
             
             return rowOfSection.count
         }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#418

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 스파크 아요 노션과 연결해두었습니다.
- 스파크, 스파크 아요 노션 모두 공개 비활해뒀습니당

🚨 **참고사항**
- 오픈소스 라이브러리 중  카카오, 파이어베이스, 로티 는 아파치 / 나머지는 MIT 였습니다. 내용이 궁금하면 아래를 참고해주세용
> https://selfish-developer.com/entry/오픈소스-라이센스-정리
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|마이페이지|<img src = "https://user-images.githubusercontent.com/69136340/159233222-c3d807bd-c847-45cd-b091-07192076cc78.mov" width ="250">|

## 📟 관련 이슈
- Resolved: #418
