### PR TITLE
[Fix] #420 - 홈 티켓 흰줄 제거 및 프로필 모서리 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Cells/Home/HomeHabitCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Home/HomeHabitCVC.swift
@@ -85,13 +85,13 @@ class HomeHabitCVC: UICollectionViewCell {
 extension HomeHabitCVC {
     private func setUI() {
         flakeImage.contentMode = .scaleAspectFill
-        ticketImage.contentMode = .scaleAspectFit
+        ticketImage.contentMode = .scaleAspectFill
         
         ddayTitleLabel.font = .h1BigtitleEng
         ddaySubtitleLabel.font = .caption
         
         [firstProfileImage, secondProfileImage, thirdProfileImage, fourthProfileImage].forEach {
-            $0?.layer.cornerRadius = 13
+            $0?.layer.cornerRadius = 14
             $0?.layer.borderWidth = 2
             $0?.layer.borderColor = UIColor.sparkWhite.cgColor
             $0?.contentMode = .scaleAspectFill


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#420

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- se2 / 13 / 13 Pro / 13 Pro Max
- 위의 기기에서 모두 확인했고, 문제 없음을 확인했습니당.
- 왼쪽 flake image 는 스보에서 비율로 잡혀있고, 우측의 ticket image 는 나머지를 채우고있는데요.
- 셀의 크기도 비율로 잡고있어서 fill 로 해도 결국 ticket image 도 비율로 잡힌다고 판단하고 수정했습니다.
- 프로필 크기가 28*28 이었어서 14로 corner radius 로 변경했습니다.
## 📟 관련 이슈
- Resolved: #420
