### PR TITLE
[Feat] #430 - 마이페이지 로그아웃, 애플/카카오 회원탈퇴 및 서버연결

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthAPI.swift
@@ -85,4 +85,37 @@ public class AuthAPI {
             return .networkFail
         }
     }
+    
+    func signout(completion: @escaping (NetworkResult<Any>) -> Void) {
+        userProvider.request(.signout) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                
+                let networkResult = self.judgeStatus(by: statusCode, data)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+    private func judgeStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<String>.self, from: data)
+        else { return .pathErr }
+        
+        switch statusCode {
+        case 200:
+            return .success(decodedData.message)
+        case 400..<500:
+            return .requestErr(decodedData.message)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthService.swift
@@ -11,6 +11,7 @@ import Moya
 enum AuthService {
     case signup(socialID: String, profileImg: UIImage?, nickname: String, fcmToken: String)
     case login(socialID: String, fcmToken: String)
+    case signout
 }
 
 extension AuthService: TargetType {
@@ -24,6 +25,8 @@ extension AuthService: TargetType {
             return "/auth/signup"
         case .login:
             return "/auth/doorbell"
+        case .signout:
+            return "/auth/signout"
         }
     }
     
@@ -33,6 +36,8 @@ extension AuthService: TargetType {
             return .post
         case .login:
             return .get
+        case .signout:
+            return .post
         }
     }
     
@@ -57,6 +62,8 @@ extension AuthService: TargetType {
             return .requestParameters(parameters: ["socialId": socialID,
                                                    "fcmToken": fcmToken],
                                       encoding: URLEncoding.queryString)
+        case .signout:
+            return .requestPlain
         }
     }
     
@@ -66,6 +73,8 @@ extension AuthService: TargetType {
             return Const.Header.multipartHeader
         case .login:
             return Const.Header.basicHeader
+        case .signout:
+            return Const.Header.authorizationHeader
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -194,12 +194,14 @@ extension MypageVC: UITableViewDelegate {
                 present(safariVC, animated: true, completion: nil)
             } else if indexPath.row == 3 {
                 // 로그아웃
-                guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
-                
-                loginVC.modalTransitionStyle = .crossDissolve
-                loginVC.modalPresentationStyle = .fullScreen
-                self.present(loginVC, animated: true) {
-                    UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+                signoutWithAPI {
+                    guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
+                    
+                    loginVC.modalTransitionStyle = .crossDissolve
+                    loginVC.modalPresentationStyle = .fullScreen
+                    self.present(loginVC, animated: true) {
+                        UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+                    }
                 }
             }
         }
@@ -317,6 +319,25 @@ extension MypageVC {
                 print("profileFetchWithAPI - serverErr")
             case .networkFail:
                 print("profileFetchWithAPI - networkFail")
+            }
+        }
+    }
+    
+    private func signoutWithAPI(completion: @escaping () -> Void) {
+        AuthAPI.shared.signout { response in
+            switch response {
+            case .success(let message):
+                completion()
+                
+                print("signoutWithAPI - success: \(message)")
+            case .requestErr(let message):
+                print("signoutWithAPI - requestErr: \(message)")
+            case .pathErr:
+                print("signoutWithAPI - pathErr")
+            case .serverErr:
+                print("signoutWithAPI - serverErr")
+            case .networkFail:
+                print("signoutWithAPI - networkFail")
             }
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/WithdrawalVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/WithdrawalVC.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import KakaoSDKUser
+
 class WithdrawalVC: UIViewController {
 
     // MARK: - Properties
@@ -104,21 +106,31 @@ extension WithdrawalVC {
         dialogueVC.dialogueType = .withdrawal
         dialogueVC.clousure = {
             if UserDefaults.standard.bool(forKey: Const.UserDefaultsKey.isAppleLogin) {
-                // TODO: - 애플 탈퇴 api
+                self.unlink()
             } else {
-                // TODO: - 카카오 탈퇴 api
+                UserApi.shared.unlink { error in
+                    if let error = error {
+                        print("kakao unlink error: \(error).")
+                    } else {
+                        // unlink success.
+                        self.unlink()
+                    }
+                }
             }
-            UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
-            UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.userID)
-            UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.isAppleLogin)
-            
-            guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
-            loginVC.modalPresentationStyle = .overFullScreen
-            loginVC.modalTransitionStyle = .crossDissolve
-            self.present(loginVC, animated: true, completion: nil)
         }
         
         present(dialogueVC, animated: true, completion: nil)
+    }
+    
+    private func unlink() {
+        UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.accessToken)
+        UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.userID)
+        UserDefaults.standard.removeObject(forKey: Const.UserDefaultsKey.isAppleLogin)
+        
+        guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
+        loginVC.modalPresentationStyle = .overFullScreen
+        loginVC.modalTransitionStyle = .crossDissolve
+        present(loginVC, animated: true, completion: nil)
     }
     
     @objc


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#430

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 로그아웃 서버통신 성공
 
<img width="700" alt="스크린샷 2022-03-29 오후 12 33 57" src="https://user-images.githubusercontent.com/69136340/160528838-f6b266f3-00c7-4b6c-8e9c-d181238ec11a.png">

- 카카오 회원탈퇴 api 연결
- 애플의 경우 별도의 회원탈퇴 기능을 제공하지 않고, 기기의 설정에서 연결된 앱을 해제할 수 있도록 하고 있어요! 
  
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|카카오회원탈퇴|<img src = "https://user-images.githubusercontent.com/69136340/160528842-ba476ac5-4b73-4751-8811-f8efa15fd1b0.mp4" width ="250">|

## 📟 관련 이슈
- Resolved: #430
