### PR TITLE
[Fix] #444 - 재로그인시 이전 계정으로 로그인되는 버그

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Constants/Const.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Const.swift
@@ -14,6 +14,4 @@ struct Const {
      Const.Xib.NibName.mainCVC 과 같이 사용.
      Notification.Name 을 extension 했기 때문에 .sendData 와 같이 사용가능.
      */
-    
-    static let accessToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) ?? ""
 }

--- a/Spark-iOS/Spark-iOS/Resource/Constants/Header.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Header.swift
@@ -10,13 +10,25 @@ import Foundation
 extension Const {
     struct Header {
         /// Content-Type: application/json
-        static let basicHeader = ["Content-Type": "application/json"]
-        /// access token 을 헤더에 담아서 보내야하는 경우에 사용.
-        static let authorizationHeader = ["Content-Type": "application/json",
-                                          "Authorization": accessToken]
+        static func basicHeader() -> [String: String] {
+            ["Content-Type": "application/json"]
+        }
         
-        static let multipartHeader = ["Content-Type": "multipart/form-data"]
-        static let multipartAuthorizationHeader = ["Content-Type": "multipart/form-data",
-                                                   "Authorization": accessToken]
+        /// "Content-Type": "application/json" 과 access token 을 헤더에 담아서 보내야하는 경우에 사용.
+        static func authorizationHeader() -> [String: String] {
+            ["Content-Type": "application/json",
+                                              "Authorization": UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) ?? ""]
+        }
+        
+        /// "Content-Type": "multipart/form-data"
+        static func multipartHeader() -> [String: String] {
+            ["Content-Type": "multipart/form-data"]
+        }
+        
+        /// "Content-Type": "multipart/form-data" 과 access token 을 헤더에 담아서 보내야하는 경우에 사용.
+        static func multipartAuthorizationHeader() -> [String: String] {
+            ["Content-Type": "multipart/form-data",
+                                                       "Authorization": UserDefaults.standard.string(forKey: Const.UserDefaultsKey.accessToken) ?? ""]
+        }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthService.swift
@@ -70,11 +70,11 @@ extension AuthService: TargetType {
     var headers: [String: String]? {
         switch self {
         case .signup:
-            return Const.Header.multipartHeader
+            return Const.Header.multipartHeader()
         case .login:
-            return Const.Header.basicHeader
+            return Const.Header.basicHeader()
         case .signout:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Feed/FeedService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Feed/FeedService.swift
@@ -59,11 +59,11 @@ extension FeedService: TargetType {
     var headers: [String: String]? {
         switch self {
         case .feedFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .feedLike:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .feedReport:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Home/HomeService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Home/HomeService.swift
@@ -43,7 +43,7 @@ extension HomeService: TargetType {
     var headers: [String: String]? {
         switch self {
         case .habitRoomFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/MyRoom/MyRoomService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/MyRoom/MyRoomService.swift
@@ -60,11 +60,11 @@ extension MyRoomService: TargetType {
     var headers: [String: String]? {
         switch self {
         case .myRoomFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .myRoomCertiFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .myRoomChangeThumbnail:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeService.swift
@@ -82,17 +82,17 @@ extension NoticeService: TargetType {
     var headers: [String: String]? {
         switch self {
         case .activeFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .serviceFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .activeRead:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .serviceRead:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .settingFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .settingPatch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Room/RoomService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Room/RoomService.swift
@@ -143,33 +143,33 @@ extension RoomService: TargetType {
     var headers: [String: String]? {
         switch self {
         case .waitingFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .codeJoinCheckFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .enterRoom:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .waitingMemberFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .authUpload:
-            return Const.Header.multipartAuthorizationHeader
+            return Const.Header.multipartAuthorizationHeader()
         case .createRoom:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .sendSpark:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .startRoom:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .setConsiderRest:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .habitRoomDetailFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .setPurpose:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .deleteWaitingRoom:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .leaveRoom:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .readRoom:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/User/UserService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/User/UserService.swift
@@ -54,9 +54,9 @@ extension UserService: TargetType {
     var headers: [String: String]? {
         switch self {
         case .profileFetch:
-            return Const.Header.authorizationHeader
+            return Const.Header.authorizationHeader()
         case .profileEdit:
-            return Const.Header.multipartAuthorizationHeader
+            return Const.Header.multipartAuthorizationHeader()
         }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#444

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 재로그인시 이전 계정으로 로그인되는 버그를 해결했습니다!
- Moya Service 헤더가 갱신되지 않았던 문제였습니다.
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
현재 상태에서 구성하면 Const header 에서 선언한 헤더들이 바뀌지 않음을 확인했고,
다음과 같이 변경하니까 됐습니다.

<img src="https://user-images.githubusercontent.com/69136340/160757293-1b5e3823-7610-46af-8468-b6e4184f46ff.png" width ="600">

그런데 이렇게 하면 안됐습니다.
<img src="https://user-images.githubusercontent.com/69136340/160757383-880b5aa0-2319-4582-a205-340eecbb0a55.png" width ="500">

이게 매번 선언해주는게 아닌 변수를 사용하다보니까 그런거 같아요
Const.accessToken 은 유저디폴트를 호출하는 함수가 아니라 그냥 유저디폴트가 가져온 변수를 저장하는 거니까 재호출이 아니라서 갱신이 안되는듯 합니다!
애초에 변하는 값인 UserDefaults 를 Const 에 `타입프로퍼티` 로 둔게 잘못이었던것 같아요

그래서 `타입메서드` 로 구성해서 다시금 UserDefaults 가 재호출되어 갱신된 값을 사용할 수 있도록 했습니다.
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/69136340/160757209-b6542cd8-74f9-4dfa-9834-26b511ff44e8.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #444
