### PR TITLE
[Chore] #429 - 나의 목표 작성, 프로필 설정, 방 생성 뷰에서 화면전환 시 노티 삭제

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -77,6 +77,7 @@ class CreateRoomVC: UIViewController {
     // MARK: - Screen Change
 
     private func dismissToHomeVC() {
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
         dismiss(animated: true, completion: nil)
     }
     
@@ -93,6 +94,7 @@ class CreateRoomVC: UIViewController {
     func touchNextButton() {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.createAuth, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.createAuth) as? CreateAuthVC else { return }
         nextVC.roomName = textField.text ?? ""
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
         navigationController?.pushViewController(nextVC, animated: true)
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -165,6 +165,7 @@ class GoalWritingVC: UIViewController {
     
     @objc
     func touchCloseButton() {
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
         dismiss(animated: true, completion: nil)
     }
 }
@@ -177,6 +178,7 @@ extension GoalWritingVC {
             switch response {
             case .success(let message):
                 print("setPurposeWithAPI - success: \(message)")
+                NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
                 self.dismiss(animated: true, completion: nil)
             case .requestErr(let message):
                 print("setPurposeWithAPI - requestErr: \(message)")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -148,10 +148,12 @@ class ProfileSettingVC: UIViewController {
     func touchCompleteButton() {
         if profileImageView.image == UIImage(named: "profileEmpty") {
             signupWithAPI(profileImg: nil, nickname: textField.text ?? "") {
+                NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
                 self.presentToMainTBC()
             }
         } else {
             signupWithAPI(profileImg: profileImageView.image ?? UIImage(), nickname: textField.text ?? "") {
+                NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
                 self.presentToMainTBC()
             }
         }
@@ -159,6 +161,7 @@ class ProfileSettingVC: UIViewController {
     
     @objc
     func touchCloseButton() {
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
         dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#429

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 나의 목표 작성
- 프로필 설정
- 방 생성 

화면 전환 시 `UITextField.textDidChangeNotification` 노티 삭제


## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
삭제를 안해줄 경우 다른 뷰에 영향을 주는 문제가 호오옥시나 생길까봐 삭제해줫습니다.


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #429 
