### PR TITLE
[Feat] #452 - 대기방에서 홈으로 갈 때 습관방 리스트 조회하기

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -56,7 +56,7 @@ class AuthTimerVC: UIViewController {
         customNavigationBar.title(roomName ?? "")
             .leftButtonImage("icQuit")
             .leftButtonAction {
-                self.dismissToHabitRoom()
+                self.dismissAuthTimerVC()
             }
         
         firstLabel.text = "1"
@@ -103,7 +103,7 @@ class AuthTimerVC: UIViewController {
         button.layer.cornerRadius = 2
     }
     
-    func dismissToHabitRoom() {
+    func dismissAuthTimerVC() {
         if timeLabel.text != "00:00:00" {
             guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
             dialogVC.dialogueType = .exitTimer

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -42,7 +42,7 @@ class CreateRoomVC: UIViewController {
         customNavigationBar.title("")
             .leftButtonImage("icQuit")
             .leftButtonAction {
-                self.dismissToHomeVC()
+                self.dismissCreateRoomVC()
             }
         
         titleLabel.text = "어떤 습관방을 만들건가요?"
@@ -76,7 +76,7 @@ class CreateRoomVC: UIViewController {
     
     // MARK: - Screen Change
 
-    private func dismissToHomeVC() {
+    private func dismissCreateRoomVC() {
         dismiss(animated: true, completion: nil)
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -459,3 +459,11 @@ extension HomeVC {
         }
     }
 }
+
+// MARK: - UIGestureRecognizerDelegate
+// FIXME: - 네비게이션 extension 정리후 공통으로 빼서 사용하기
+extension HomeVC: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return navigationController?.viewControllers.count ?? 0 > 1
+    }
+}

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -387,7 +387,6 @@ extension HomeVC: UICollectionViewDataSource {
         } else {
             guard let waitingCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.homeWaitingCVC, for: indexPath) as? HomeWaitingCVC else { return UICollectionViewCell() }
             return waitingCVC
-//            return UICollectionViewCell()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -127,7 +127,7 @@ extension WaitingVC {
             customNavigationBar.title(title)
                 .leftButtonImage("icHome")
                 .leftButtonAction {
-                    self.dismissJoinCodeToHomeVC()
+                    self.dismissFromJoinCode()
                 }
                 .rightButtonImage("icMoreVerticalBlack")
                 .rightButtonAction {
@@ -137,7 +137,7 @@ extension WaitingVC {
             customNavigationBar.title(title)
                 .leftButtonImage("icHome")
                 .leftButtonAction {
-                    self.dismissToHomeVC()
+                    self.dismissWaitingVC()
                 }
                 .rightButtonImage("icMoreVerticalBlack")
                 .rightButtonAction {
@@ -423,12 +423,13 @@ extension WaitingVC {
         navigationController?.popViewController(animated: true)
     }
     
-    private func dismissToHomeVC() {
+    private func dismissWaitingVC() {
         presentingViewController?.presentingViewController?.dismiss(animated: true)
     }
     
-    private func dismissJoinCodeToHomeVC() {
+    private func dismissFromJoinCode() {
         presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true)
+        NotificationCenter.default.post(name: .updateHome, object: nil)
         NotificationCenter.default.post(name: .appearFloatingButton, object: nil)
     }
     
@@ -485,7 +486,7 @@ extension WaitingVC {
                 case .fromHome:
                     self.popToHomeVC()
                 case .makeRoom:
-                    self.dismissToHomeVC()
+                    self.dismissWaitingVC()
                 case .joinCode:
                     // 코드로 참여시에는 createButton 이 히든되어 있어서 아무런 동작이 필요하지 않다.
                     return
@@ -562,7 +563,7 @@ extension WaitingVC {
                 case .fromHome:
                     self.popToHomeVC()
                 case .makeRoom:
-                    self.dismissToHomeVC()
+                    self.dismissWaitingVC()
                 case .joinCode:
                     // 방장만 방 삭제 API를 사용하기 때문에 발생하지 않음.
                     return
@@ -592,9 +593,9 @@ extension WaitingVC {
                 case .fromHome:
                     self.popToHomeVC()
                 case .makeRoom:
-                    self.dismissToHomeVC()
+                    self.dismissWaitingVC()
                 case .joinCode:
-                    self.dismissJoinCodeToHomeVC()
+                    self.dismissFromJoinCode()
                 case .none:
                     print("fromeWhereStatus 를 지정해주세요.")
                 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#452

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 코드로 참여시 대기방에서 홈으로 갈 때 홈 리스트가 조회되지 않았어요
- 코드로 참여하는 뷰가 overfullscreen 으로 보여지기 때문에 홈의 viewWillAppear 가 다시금 호출되지 않았어요 그래서 노티를 사용했습니다.
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 예전에 네비바를 히든하고 팝 스와이프 제스처를 하게되면 루트뷰컨트롤러에서 에러가 발생한다 그래서 확인해줘야한다는
```swift
// MARK: - UIGestureRecognizerDelegate
// FIXME: - 네비게이션 extension 정리후 공통으로 빼서 사용하기
extension HomeVC: UIGestureRecognizerDelegate {
    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
        return navigationController?.viewControllers.count ?? 0 > 1
    }
}
```

이부분 기억나시나용 지금 홈에서 그렇더라구여 그래서 홈도 이 풀리퀘에서 적용해주었고, 피드와 내 보관함은 문제없더라구요 루트뷰컨이 아니라서 그런가봐요 그래서 탭바를 히든해도 별 상관이 없는거죠 그래서 이 부분을 extension으로 정리하고 싶네여
좀 더 고민해보고 이슈를 파서 진행할게여!
## 📟 관련 이슈
- Resolved: #452
