### PR TITLE
[Feat] #400 - SplashVC 에서 doorbell API 로 엑세스 토큰 갱신하기

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
@@ -107,6 +107,7 @@ extension SplashVC {
     }
     
     private func presentToLogin() {
+    private func presentToLoginVC() {
         guard let loginVC = UIStoryboard(name: Const.Storyboard.Name.login, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.login) as? LoginVC else { return }
         loginVC.modalPresentationStyle = .fullScreen
         loginVC.modalTransitionStyle = .crossDissolve
@@ -114,6 +115,7 @@ extension SplashVC {
     }
 
     private func presentToOnboarding() {
+    private func presentToOnboardingVC() {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.onboarding, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.onboarding) as? OnboardingVC else { return }
         nextVC.modalPresentationStyle = .fullScreen
         


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#400

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 액세스토큰의 갱신을 위해서 doorBell API 를 스플래쉬 뷰컨트롤러에서 호출합니다. 이를 통해 매 접속시마다 액세스 토큰을 갱신합니다.
> 추후 업데이트를 통해서 토큰 만료의 경우를 대비하는 API 를 붙일 예정입니다.
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

- 성공적으로 doorBell API 를 통해서 스플래쉬 뷰컨트롤러에서 액세스 토큰을 받고, 갱신해서 홈에서 호출해주는 것을 볼 수 있습니다!

<img src="https://user-images.githubusercontent.com/69136340/160964432-4829b6e1-1b9e-4b0f-9f4e-1994bd31ccae.png" width="700">

## 📟 관련 이슈
- Resolved: #400
