### PR TITLE
[Fix] #471 - 팝업창 subtitle 가운데 정렬하기

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/CompleteFailDialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/CompleteFailDialogueVC.swift
@@ -50,11 +50,11 @@ extension CompleteFailDialogueVC {
         
         titleLabel.textColor = .sparkPinkred
         titleLabel.font = .enMediumItatlicFont(ofSize: 24.0)
-        titleLabel.textAlignment = .center
         
         subtitleLable.textColor = .sparkDeepGray
         subtitleLable.font = .p1TitleLight
         subtitleLable.numberOfLines = 2
+        subtitleLable.textAlignment = .center
         
         if let roomStatus = roomStatus {
             switch roomStatus {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#471

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 팝업창 subtitle 가운데 정렬하기

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|팝업|<img src = "https://user-images.githubusercontent.com/69136340/161372493-49274d6d-7034-4dec-aed6-16da062a3bf3.PNG" width ="250">|

## 📟 관련 이슈
- Resolved: #471
