### PR TITLE
[Fix] #476 - 습관 인증 스톱워치 백그라운드에서 멈추는 문제 해결

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Constants/UserDefaultsKey.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/UserDefaultsKey.swift
@@ -15,5 +15,7 @@ extension Const {
         static let accessToken = "accessToekn"
         static let fcmToken = "fcmToken"
         static let checkHabitRoomGuide = "checkHabitRoomGuide"
+        static let sceneWillEnterForeground = "sceneWillEnterForeground"
+        static let sceneDidEnterBackground = "sceneDidEnterBackground"
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -41,19 +41,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillResignActive(_ scene: UIScene) {
     }
 
-    /// Foreground에 들어올 때
-    /// sceneDidEnterBackground라는 키워드로 저장해둔 값을 sceneWillEnterForeground라는 키워드 노티의 userInfo로 전달
+    // Foreground에 들어올 때
+    // sceneDidEnterBackground라는 키워드로 저장해둔 값을 sceneWillEnterForeground라는 키워드 노티의 userInfo로 전달
     func sceneWillEnterForeground(_ scene: UIScene) {
         guard let start = UserDefaults.standard.object(forKey: Const.UserDefaultsKey.sceneDidEnterBackground) as? Date else { return }
         let interval = Int(Date().timeIntervalSince(start))
         NotificationCenter.default.post(name: NSNotification.Name(Const.UserDefaultsKey.sceneWillEnterForeground), object: nil, userInfo: ["time": interval])
     }
 
-    /// Background에 들어갈때
-    /// sceneDidEnterBackground라는 키워드의 노티 전달하며
-    /// sceneDidEnterBackground라는 키워드로 값 저장
+    // Background에 들어갈때
+    // sceneDidEnterBackground라는 키워드의 노티 전달하며
+    // sceneDidEnterBackground라는 키워드로 값 저장
     func sceneDidEnterBackground(_ scene: UIScene) {
-        NotificationCenter.default.post(name: NSNotification.Name(Const.UserDefaultsKey.sceneDidEnterBackground), object: nil)
         UserDefaults.standard.setValue(Date(), forKey: Const.UserDefaultsKey.sceneDidEnterBackground)
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -41,14 +41,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillResignActive(_ scene: UIScene) {
     }
 
+    /// Foreground에 들어올 때
+    /// sceneDidEnterBackground라는 키워드로 저장해둔 값을 sceneWillEnterForeground라는 키워드 노티의 userInfo로 전달
     func sceneWillEnterForeground(_ scene: UIScene) {
-        guard let start = UserDefaults.standard.object(forKey: "sceneDidEnterBackground") as? Date else { return }
+        guard let start = UserDefaults.standard.object(forKey: Const.UserDefaultsKey.sceneDidEnterBackground) as? Date else { return }
         let interval = Int(Date().timeIntervalSince(start))
-        NotificationCenter.default.post(name: NSNotification.Name("sceneWillEnterForeground"), object: nil, userInfo: ["time": interval])
+        NotificationCenter.default.post(name: NSNotification.Name(Const.UserDefaultsKey.sceneWillEnterForeground), object: nil, userInfo: ["time": interval])
     }
 
+    /// Background에 들어갈때
+    /// sceneDidEnterBackground라는 키워드의 노티 전달하며
+    /// sceneDidEnterBackground라는 키워드로 값 저장
     func sceneDidEnterBackground(_ scene: UIScene) {
-        NotificationCenter.default.post(name: NSNotification.Name("sceneDidEnterBackground"), object: nil)
-        UserDefaults.standard.setValue(Date(), forKey: "sceneDidEnterBackground")
+        NotificationCenter.default.post(name: NSNotification.Name(Const.UserDefaultsKey.sceneDidEnterBackground), object: nil)
+        UserDefaults.standard.setValue(Date(), forKey: Const.UserDefaultsKey.sceneDidEnterBackground)
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -42,8 +42,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
+        guard let start = UserDefaults.standard.object(forKey: "sceneDidEnterBackground") as? Date else { return }
+        let interval = Int(Date().timeIntervalSince(start))
+        NotificationCenter.default.post(name: NSNotification.Name("sceneWillEnterForeground"), object: nil, userInfo: ["time": interval])
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
+        NotificationCenter.default.post(name: NSNotification.Name("sceneDidEnterBackground"), object: nil)
+        UserDefaults.standard.setValue(Date(), forKey: "sceneDidEnterBackground")
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -49,8 +49,8 @@ class AuthTimerVC: UIViewController {
         navigationController?.isNavigationBarHidden = true
         navigationController?.interactivePopGestureRecognizer?.delegate = self
         
-        NotificationCenter.default.addObserver(self, selector: #selector(checkForground), name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(checkForground), name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
     // MARK: - Methods
@@ -96,10 +96,10 @@ class AuthTimerVC: UIViewController {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(resetTimer(_:)), name: .resetStopWatch, object: nil)
-        // 백그라운드에서 포어그라운드로 돌아올때
-        NotificationCenter.default.addObserver(self, selector: #selector(checkForground), name: NSNotification.Name("sceneWillEnterForeground"), object: nil)
-        // 포어그라운드에서 백그라운드로 갈때
-        NotificationCenter.default.addObserver(self, selector: #selector(checkForground(_:)), name: NSNotification.Name("sceneDidEnterBackground"), object: nil)
+        // Background -> Foreground
+        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: NSNotification.Name(Const.UserDefaultsKey.sceneWillEnterForeground), object: nil)
+        // Foreground -> Background
+        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer(_:)), name: NSNotification.Name(Const.UserDefaultsKey.sceneDidEnterBackground), object: nil)
     }
     
     private func setButton(_ button: UIButton, title: String, backgroundColor: UIColor, isEnable: Bool) {
@@ -170,7 +170,7 @@ class AuthTimerVC: UIViewController {
     }
     
     @objc
-    func checkForground(_ notification: NSNotification) {
+    func checkBackgroundTimer(_ notification: NSNotification) {
         if let isValid = timer?.isValid {
             if isTimerOn && isValid {
                 let time = notification.userInfo?["time"] as? Int ?? 0

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -100,10 +100,7 @@ class AuthTimerVC: UIViewController {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(resetTimer(_:)), name: .resetStopWatch, object: nil)
-        // Background -> Foreground
         NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: NSNotification.Name(Const.UserDefaultsKey.sceneWillEnterForeground), object: nil)
-        // Foreground -> Background
-        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: NSNotification.Name(Const.UserDefaultsKey.sceneDidEnterBackground), object: nil)
     }
     
     private func setButton(_ button: UIButton, title: String, backgroundColor: UIColor, isEnable: Bool) {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -48,9 +48,13 @@ class AuthTimerVC: UIViewController {
         
         navigationController?.isNavigationBarHidden = true
         navigationController?.interactivePopGestureRecognizer?.delegate = self
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name(Const.UserDefaultsKey.sceneWillEnterForeground), object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name(Const.UserDefaultsKey.sceneDidEnterBackground), object: nil)
     }
     
     // MARK: - Methods
@@ -99,7 +103,7 @@ class AuthTimerVC: UIViewController {
         // Background -> Foreground
         NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: NSNotification.Name(Const.UserDefaultsKey.sceneWillEnterForeground), object: nil)
         // Foreground -> Background
-        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer(_:)), name: NSNotification.Name(Const.UserDefaultsKey.sceneDidEnterBackground), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: NSNotification.Name(Const.UserDefaultsKey.sceneDidEnterBackground), object: nil)
     }
     
     private func setButton(_ button: UIButton, title: String, backgroundColor: UIColor, isEnable: Bool) {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#476

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 습관 인증 스톱워치 백그라운드에서 멈추는 문제 해결
- 자그마한 함수 순서 변경 및 이름 변경

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
일단은 백그라운드에 있는 경우에도 스톱워치가 작동하도록 하기 위해
background로 들어갈 때, foreground로 들어올때의 시간차를 초 단위로 구해
기존의 currentCountTime이라는 초 단위의 친구에게 더해주도록 했습니다.

+ 일단은 백그라운드에 두더라도 앱이 갱신되지 않는 시간 내에는 문제 없이 작동하도록 했습니다.
백그라운드에 뒀다가 앱 자체가 갱신돼서 스플래시부터 시작하는 경우는 따로 이슈를 만들어서 고민해봐야 할 것 같습니다.



## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|-|<img src = "https://user-images.githubusercontent.com/81167570/161437167-a0735ae1-0e4e-4013-accc-0d90d9b92e2a.gif" width ="250">|




## 📟 관련 이슈
- Resolved: #476 
