### PR TITLE
[Feat] #462 - 스파크 보내기 뷰 이모지 키보드 관련 레이아웃 대응

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -17,6 +17,8 @@ class SendSparkVC: UIViewController {
     var profileImage: String?
     private var maxLength: Int = 15
     private let screenHeight: CGFloat = UIScreen.main.bounds.height
+    private var usernameLabelOriginalY: CGFloat = 0
+    private var lineViewOriginalY: CGFloat = 0
     
     private var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
 
@@ -190,16 +192,7 @@ extension SendSparkVC {
             let lineViewHeight: CGFloat = 2
             let targetY: CGFloat = screenHeight - keyboardHeight - 20 - lineViewHeight
             
-            sendButton.snp.makeConstraints { make in
-                make.trailing.equalTo(lineView.snp.trailing).inset(2.5)
-                make.bottom.equalTo(lineView.snp.top).offset(-4)
-            }
-            
-            lineView.snp.makeConstraints { make in
-                make.height.equalTo(2)
-                make.leading.trailing.equalToSuperview().inset(20)
-                make.top.equalToSuperview().inset(targetY)
-            }
+            usernameLabelOriginalY = usernameLabelOriginalY == 0 ? userNameLabel.frame.origin.y : usernameLabelOriginalY
             lineViewOriginalY = lineViewOriginalY == 0 ? lineView.frame.origin.y : lineViewOriginalY
             
             lineView.frame.origin.y = targetY
@@ -208,6 +201,14 @@ extension SendSparkVC {
             userNameLabel.frame.origin.y = targetY - userNameLabel.frame.height - 98
             profileImageView.frame.origin.y = targetY - profileImageView.frame.height - 136
         }
+    }
+    
+    @objc func keyWillHide(_ notification: NSNotification) {
+        userNameLabel.frame.origin.y = usernameLabelOriginalY
+        profileImageView.frame.origin.y = usernameLabelOriginalY - profileImageView.frame.height - 12
+        lineView.frame.origin.y = lineViewOriginalY
+        sendButton.frame.origin.y = lineViewOriginalY - sendButton.frame.height - 4
+        textField.frame.origin.y = lineViewOriginalY - textField.frame.height - 10
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -149,11 +149,13 @@ extension SendSparkVC {
     }
     
     private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(keyBoardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyBoardChange), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     private func removeObservers() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     // MARK: - @objc Function
@@ -181,7 +183,7 @@ extension SendSparkVC {
         }
     }
     
-    @objc func keyBoardWillShow(_ notification: NSNotification) {
+    @objc func keyBoardChange(_ notification: NSNotification) {
         if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             let keyboardRectangle = keyboardFrame.cgRectValue
             let keyboardHeight = keyboardRectangle.height
@@ -198,11 +200,13 @@ extension SendSparkVC {
                 make.leading.trailing.equalToSuperview().inset(20)
                 make.top.equalToSuperview().inset(targetY)
             }
+            lineViewOriginalY = lineViewOriginalY == 0 ? lineView.frame.origin.y : lineViewOriginalY
             
-            textField.snp.makeConstraints { make in
-                make.leading.equalTo(lineView.snp.leading).offset(8)
-                make.bottom.equalTo(lineView.snp.top).offset(-10)
-            }
+            lineView.frame.origin.y = targetY
+            sendButton.frame.origin.y = targetY - sendButton.frame.height - 4
+            textField.frame.origin.y = targetY - textField.frame.height - 10
+            userNameLabel.frame.origin.y = targetY - userNameLabel.frame.height - 98
+            profileImageView.frame.origin.y = targetY - profileImageView.frame.height - 136
         }
     }
 }
@@ -355,6 +359,21 @@ extension SendSparkVC {
         guideLabel.snp.makeConstraints { make in
             make.bottom.equalToSuperview().inset(44)
             make.centerX.equalToSuperview()
+        }
+        
+        sendButton.snp.makeConstraints { make in
+            make.trailing.equalTo(lineView.snp.trailing).inset(2.5)
+            make.bottom.equalTo(lineView.snp.top).offset(-4)
+        }
+        
+        lineView.snp.makeConstraints { make in
+            make.height.equalTo(2)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        textField.snp.makeConstraints { make in
+            make.leading.equalTo(lineView.snp.leading).offset(8)
+            make.bottom.equalTo(lineView.snp.top).offset(-10)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -347,7 +347,7 @@ extension SendSparkVC {
         }
         
         userNameLabel.snp.makeConstraints { make in
-            make.bottom.equalTo(buttonCV.snp.top).offset(-200)
+            make.bottom.equalTo(buttonCV.snp.top).offset(UIScreen.main.hasNotch ? -200 : -140)
             make.centerX.equalToSuperview()
         }
         
@@ -370,6 +370,7 @@ extension SendSparkVC {
         lineView.snp.makeConstraints { make in
             make.height.equalTo(2)
             make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 305 : 250)
         }
         
         textField.snp.makeConstraints { make in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -19,6 +19,9 @@ class SendSparkVC: UIViewController {
     private let screenHeight: CGFloat = UIScreen.main.bounds.height
     private var usernameLabelOriginalY: CGFloat = 0
     private var lineViewOriginalY: CGFloat = 0
+    private var originYDif: CGFloat = 0
+    private var purposedY: CGFloat = 0
+    private var canChangeKeyboardFrame: Bool = false
     
     private var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
 
@@ -151,11 +154,13 @@ extension SendSparkVC {
     }
     
     private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyDidShow), name: UIResponder.keyboardDidShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyBoardChange), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     private func removeObservers() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardDidShowNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
@@ -185,6 +190,14 @@ extension SendSparkVC {
         }
     }
     
+    @objc func keyDidShow(_ notification: NSNotification) {
+        // 키보드가 완전히 올라온 이후에 프로필 이미지와 닉네임 라벨의 위치 변화가 있을 수 있음을 설정하는 부분
+        canChangeKeyboardFrame = true
+        // UI 요소들의 원래 위치를 기억하기 위한 코드
+        usernameLabelOriginalY = usernameLabelOriginalY == 0 ? userNameLabel.frame.origin.y : usernameLabelOriginalY
+        lineViewOriginalY = lineViewOriginalY == 0 ? lineView.frame.origin.y : lineViewOriginalY
+    }
+    
     @objc func keyBoardChange(_ notification: NSNotification) {
         if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             let keyboardRectangle = keyboardFrame.cgRectValue
@@ -192,14 +205,21 @@ extension SendSparkVC {
             let lineViewHeight: CGFloat = 2
             let targetY: CGFloat = screenHeight - keyboardHeight - 20 - lineViewHeight
             
-            usernameLabelOriginalY = usernameLabelOriginalY == 0 ? userNameLabel.frame.origin.y : usernameLabelOriginalY
-            lineViewOriginalY = lineViewOriginalY == 0 ? lineView.frame.origin.y : lineViewOriginalY
+            // keyBoarFrameDidChange는 맨 처음 키보드가 올라올 때와, 키보드의 프레임 변화(이모지 키보드로의 전환)가 있을 때 모두 불림. 처음에는 originDif 에 targetY의 값을 저장하고, 이모지 키보드로 전환되었을 때 targetY의 변화값을 originDif에 저장한다.
+            // originDif에 targetY의 변화값이 저장되었을 때 비로소 purposedY에 그 값이 저장된다. 초기화 이후로 purposedY의 값은 유지된다.
+            originYDif = CGFloat(abs(Int(originYDif)-Int(targetY))) != originYDif ? targetY - originYDif : originYDif
+            purposedY = (originYDif < 0)&&(purposedY == 0) ? originYDif : purposedY
             
             lineView.frame.origin.y = targetY
             sendButton.frame.origin.y = targetY - sendButton.frame.height - 4
             textField.frame.origin.y = targetY - textField.frame.height - 10
-            userNameLabel.frame.origin.y = targetY - userNameLabel.frame.height - 98
-            profileImageView.frame.origin.y = targetY - profileImageView.frame.height - 136
+            
+            // keyBoardDidShow 메서드가 canChangeKeyboardFrame을 true로 만든 이후, 즉 키보드가 모두 올라온 이후에만 아래 코드블럭이 기능함. 이는 이모지 키보드로 전환했을 때에만 아래 코드블록이 기능하도록 한 것임.
+            if canChangeKeyboardFrame {
+                userNameLabel.frame.origin.y += purposedY
+                profileImageView.frame.origin.y += purposedY
+                purposedY = -purposedY
+            }
         }
     }
     
@@ -209,6 +229,10 @@ extension SendSparkVC {
         lineView.frame.origin.y = lineViewOriginalY
         sendButton.frame.origin.y = lineViewOriginalY - sendButton.frame.height - 4
         textField.frame.origin.y = lineViewOriginalY - textField.frame.height - 10
+        
+        // 이모지 키보드로 전환하고 바로 키보드를 내린 경우에 purposedY의 값을 반전시켜 줘야한다.
+        if purposedY > 0 { purposedY = -purposedY }
+        canChangeKeyboardFrame = false
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -206,9 +206,9 @@ extension SendSparkVC {
             let targetY: CGFloat = screenHeight - keyboardHeight - 20 - lineViewHeight
             
             // keyBoarFrameDidChange는 맨 처음 키보드가 올라올 때와, 키보드의 프레임 변화(이모지 키보드로의 전환)가 있을 때 모두 불림. 처음에는 originDif 에 targetY의 값을 저장하고, 이모지 키보드로 전환되었을 때 targetY의 변화값을 originDif에 저장한다.
-            // originDif에 targetY의 변화값이 저장되었을 때 비로소 purposedY에 그 값이 저장된다. 초기화 이후로 purposedY의 값은 유지된다.
+            // originDif에 targetY의 변화값이 저장되었을 때 비로소 purposedY에 그 값이 저장된다. 한 번 초기화 이후로 purposedY의 값은 유지된다.
             originYDif = CGFloat(abs(Int(originYDif)-Int(targetY))) != originYDif ? targetY - originYDif : originYDif
-            purposedY = (originYDif < 0)&&(purposedY == 0) ? originYDif : purposedY
+            purposedY = (originYDif < 0) && (purposedY == 0) ? originYDif : purposedY
             
             lineView.frame.origin.y = targetY
             sendButton.frame.origin.y = targetY - sendButton.frame.height - 4
@@ -218,6 +218,7 @@ extension SendSparkVC {
             if canChangeKeyboardFrame {
                 userNameLabel.frame.origin.y += purposedY
                 profileImageView.frame.origin.y += purposedY
+                // 키보드가 전환될 떄마다 purposedY 값을 반전시켜줍니다
                 purposedY = -purposedY
             }
         }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#462

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 이모지 키보드로 전환 시 원래의 간격만큼 프로필 이미지 뷰와 닉네임 라벨이 움직이도록 수정
- 프로필 이미지가 위로 올라간 상태에서 키보드를 내리면 다시 돌아오도록 애니메이션

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
1. Layout 설정 위치 변경 & originY를 바꿔주는 방식으로 변경 :  기존에 키보드 등장 시 Snapkit으로 Layout을 잡아주는 방법은 View Layout Cycle에 의해 y좌표가 여러번 바뀌어야 하는 상황에서 유효하지 않았음.
2. @objc `keyBoardDidHide` : 유저네임 라벨과 프로필 이미지뷰의 위치가 변한 경우 원래 좌표를 기억해주기 위해 `originalY` 변수 초기화, 키보드가 완전히 올라온 다음에 `keyBoardFrameDidChange` 메서드를 사용하기 위해 `canChangeKeyBoardFrame` 변수 초기화 
3. @objc `keyBoardFrameDidChange` : 키보드가 등장하고, 이모지 키보드로 전환된 경우에만 y좌표의 차이를 `originYDif` 변수에 저장. `originYDif` 변수에 올바른 값이 저장되면 `purposedY`에 이를 다시 할당. 이모지 키보드로 전환될 때마다 `purposedY`의 값을 반전시켜서 `userNameLabel`과 `profileImageView`가 위아래로 움직이도록 함
4. @objc `keyBoardWillHide` : 프로필이미지뷰가 위로 올라간 경우 원래 위치로 돌아가도록 하는 애니메이션 설정

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/77208067/161882966-fac965e0-735d-47ba-a3ff-c274cd7f9ad9.mp4" width ="250">|

## 📟 관련 이슈
- Resolved: #462 
