### PR TITLE
[Feat] #470 - 대표이미지 변경 뷰 셀 필터링 및 완료버튼 동작 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -262,7 +262,12 @@ extension StorageMoreVC {
             switch response {
             case .success(let data):
                 if let myRoomCerti = data as? MyRoomCertification {
-                    self.myRoomCertificationList?.append(contentsOf: myRoomCerti.records ?? [])
+                    if (self.isChangingImageView) {
+                        let filteredData = myRoomCerti.records?.filter({ $0.status == "DONE" })
+                        self.myRoomCertificationList?.append(contentsOf: filteredData ?? [])
+                    } else {
+                        self.myRoomCertificationList?.append(contentsOf: myRoomCerti.records ?? [])
+                    }
                     self.storageMoreCV.reloadData()
                 }
                 completion()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -106,7 +106,11 @@ extension StorageMoreVC {
                 }
                 .rightButtonPinkTitle("완료")
                 .rightButtonAction {
-                    self.myRoomChangeThumbnailWithAPI(roomId: self.roomID ?? 0, recordId: self.selectedRecordId ?? 0)
+                    if let selected = self.selectedRecordId {
+                        self.myRoomChangeThumbnailWithAPI(roomId: self.roomID ?? 0, recordId: selected )
+                    } else {
+                        self.dismiss(animated: true)
+                    }
                 }
         }
     }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#470

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 대표이미지 변경 뷰에서 Rest, None 상태의 티켓이 보이지 않도록 필터링
- 변경되는 이미지가 선택되지 않았더라도 완료버튼이 눌리도록 하기

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/77208067/162698694-2b2b2fec-e87e-426a-a89f-022cd698ef3d.mp4" width ="250">|
|GIF|<img src = "https://user-images.githubusercontent.com/77208067/162698714-3348d5ce-9bb1-4dff-b5a3-4ee1625a2ac4.mp4" width ="250">|

## 📟 관련 이슈
- Resolved: #470 
