### PR TITLE
[Fix] #528 - 프로필 수정 뷰 노티 삭제

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -41,6 +41,12 @@ class EditProfileVC: UIViewController {
         setAddTarget()
         setDelegate()
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        removeObservers()
+    }
 }
     
     // MARK: - Extension
@@ -100,6 +106,10 @@ extension EditProfileVC {
     private func setAddTarget() {
         completeButton.addTarget(self, action: #selector(touchCompleteButton), for: .touchUpInside)
         tap.addTarget(self, action: #selector(showAlert))
+    }
+    
+    private func removeObservers() {
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
     }
     
     private func openLibrary() {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#528

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
프로필 수정 뷰의 willDisappear에서 observer을 지워줬습니다.


## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
이제 제가 알고 있는 텍스트 필드가 있는 뷰에는 전부 노티를 삭제해준 것 같습니다..
이젠 진짜 텍필 노티 관련 문제가 없을 것이라 믿습니다..


## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## 📟 관련 이슈
- Resolved: #528 
