### PR TITLE
[Feat] #458 - 네트워크 손실 시 alert구현

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -1922,7 +1922,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Spark-iOS/Spark-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Spark-iOS/Resource/Info.plist";
@@ -1960,7 +1960,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Spark-iOS/Spark-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Spark-iOS/Resource/Info.plist";
@@ -1993,7 +1993,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SparkNotificationService/Info.plist;
@@ -2020,7 +2020,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SparkNotificationService/Info.plist;

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthAPI.swift
@@ -6,15 +6,15 @@
 //
 
 import Foundation
+
 import Moya
 
 public class AuthAPI {
-    
-    static let shared = AuthAPI()
-    var userProvider = MoyaProvider<AuthService>(plugins: [MoyaLoggerPlugin()])
-    
-    // 객체화할 수 없게 만들어서 싱글톤 패턴으로만 사용하도록 접근 제어자 설정.
-    private init() { }
+    var userProvider: MoyaProvider<AuthService>
+
+    public init(viewController: UIViewController) {
+        userProvider = MoyaProvider<AuthService>(plugins: [MoyaLoggerPlugin(viewController: viewController)])
+    }
     
     func signup(socialID: String, profileImg: UIImage?, nickname: String, fcmToken: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         userProvider.request(.signup(socialID: socialID, profileImg: profileImg, nickname: nickname, fcmToken: fcmToken)) { result in

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Feed/FeedAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Feed/FeedAPI.swift
@@ -11,10 +11,10 @@ import Moya
 
 public class FeedAPI {
     
-    static let shared = FeedAPI()
-    var feedProvider = MoyaProvider<FeedService>(plugins: [MoyaLoggerPlugin()])
-    
-    public init() { }
+    var feedProvider: MoyaProvider<FeedService>
+    public init(viewController: UIViewController) {
+        feedProvider = MoyaProvider<FeedService>(plugins: [MoyaLoggerPlugin(viewController: viewController)])
+    }
     
     func feedFetch(lastID: Int, size: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
         feedProvider.request(.feedFetch(lastID: lastID, size: size)) { result in

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Home/HomeAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Home/HomeAPI.swift
@@ -9,11 +9,11 @@ import Foundation
 import Moya
 
 public class HomeAPI {
-     
-    static let shared = HomeAPI()
-    var userProvider = MoyaProvider<HomeService>(plugins: [MoyaLoggerPlugin()])
+    var userProvider: MoyaProvider<HomeService>
     
-    public init() { }
+    public init(viewController: UIViewController) {
+        userProvider = MoyaProvider<HomeService>(plugins: [MoyaLoggerPlugin(viewController: viewController)])
+    }
     
     func habitRoomFetch(lastID: Int, size: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
         userProvider.request(.habitRoomFetch(lastID: lastID, size: size)) { (result) in

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/MyRoom/MyRoomAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/MyRoom/MyRoomAPI.swift
@@ -9,11 +9,12 @@ import Foundation
 import Moya
 
 public class MyRoomAPI {
-     
-    static let shared = MyRoomAPI()
-    var userProvider = MoyaProvider<MyRoomService>(plugins: [MoyaLoggerPlugin()])
     
-    public init() { }
+    var userProvider: MoyaProvider<MyRoomService>
+    
+    public init(viewController: UIViewController) {
+        self.userProvider = MoyaProvider<MyRoomService>(plugins: [MoyaLoggerPlugin(viewController: viewController)])
+    }
     
     func myRoomFetch(roomType: String, lastID: Int, size: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
         userProvider.request(.myRoomFetch(roomType: roomType, lastID: lastID, size: size)) { (result) in

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Notice/NoticeAPI.swift
@@ -10,11 +10,11 @@ import Foundation
 import Moya
 
 public class NoticeAPI {
+    var noticeProvider: MoyaProvider<NoticeService>
     
-    static let shared = NoticeAPI()
-    var noticeProvider = MoyaProvider<NoticeService>(plugins: [MoyaLoggerPlugin()])
-    
-    private init() { }
+    public init(viewController: UIViewController) {
+        noticeProvider = MoyaProvider<NoticeService>(plugins: [MoyaLoggerPlugin(viewController: viewController)])
+    }
     
     func activeFetch(lastID: Int, size: Int, completion: @escaping(NetworkResult<Any>) -> Void) {
         noticeProvider.request(.activeFetch(lastID: lastID, size: size)) { result in

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Plugin/MoyaLoggerPlugin.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Plugin/MoyaLoggerPlugin.swift
@@ -6,8 +6,9 @@
 //
 
 import Foundation
-import Moya
 import UIKit
+
+import Moya
 
 final class MoyaLoggerPlugin: PluginType {
     

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Plugin/MoyaLoggerPlugin.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Plugin/MoyaLoggerPlugin.swift
@@ -7,62 +7,70 @@
 
 import Foundation
 import Moya
+import UIKit
 
 final class MoyaLoggerPlugin: PluginType {
     
-  // Request를 보낼 때 호출
-  func willSend(_ request: RequestType, target: TargetType) {
-    guard let httpRequest = request.request else {
-      print("--> 유효하지 않은 요청")
-      return
+    private let viewController: UIViewController
+
+    init(viewController: UIViewController) {
+        self.viewController = viewController
     }
-    let url = httpRequest.description
-    let method = httpRequest.httpMethod ?? "unknown method"
-    var log = "----------------------------------------------------\n1️⃣[\(method)] \(url)\n----------------------------------------------------\n"
-    log.append("2️⃣API: \(target)\n")
-    if let headers = httpRequest.allHTTPHeaderFields, !headers.isEmpty {
-      log.append("header: \(headers)\n")
-    }
-    if let body = httpRequest.httpBody, let bodyString = String(bytes: body, encoding: String.Encoding.utf8) {
-      log.append("\(bodyString)\n")
-    }
-    log.append("------------------- END \(method) -------------------")
-    print(log)
-  }
     
-  // Response가 왔을 때
-  func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
-    switch result {
-    case let .success(response):
-      onSuceed(response)
-    case let .failure(error):
-      onFail(error)
+    // Request를 보낼 때 호출
+    func willSend(_ request: RequestType, target: TargetType) {
+        guard let httpRequest = request.request else {
+            print("--> 유효하지 않은 요청")
+            return
+        }
+        let url = httpRequest.description
+        let method = httpRequest.httpMethod ?? "unknown method"
+        var log = "----------------------------------------------------\n1️⃣[\(method)] \(url)\n----------------------------------------------------\n"
+        log.append("2️⃣API: \(target)\n")
+        if let headers = httpRequest.allHTTPHeaderFields, !headers.isEmpty {
+            log.append("header: \(headers)\n")
+        }
+        if let body = httpRequest.httpBody, let bodyString = String(bytes: body, encoding: String.Encoding.utf8) {
+            log.append("\(bodyString)\n")
+        }
+        log.append("------------------- END \(method) -------------------")
+        print(log)
     }
-  }
     
-  func onSuceed(_ response: Response) {
-    let request = response.request
-    let url = request?.url?.absoluteString ?? "nil"
-    let statusCode = response.statusCode
-    var log = "------------------- 네트워크 통신 성공 -------------------"
-    log.append("\n3️⃣[\(statusCode)] \(url)\n----------------------------------------------------\n")
-    log.append("response: \n")
-    if let reString = String(bytes: response.data, encoding: String.Encoding.utf8) {
-      log.append("4️⃣\(reString)\n")
+    // Response가 왔을 때
+    func didReceive(_ result: Result<Response, MoyaError>, target: TargetType) {
+        switch result {
+        case let .success(response):
+            onSucceed(response)
+        case let .failure(error):
+            onFail(error)
+        }
     }
-    log.append("------------------- END HTTP -------------------")
-    print(log)
-  }
     
-  func onFail(_ error: MoyaError) {
-    if let response = error.response {
-      onSuceed(response)
-      return
+    func onSucceed(_ response: Response) {
+        let request = response.request
+        let url = request?.url?.absoluteString ?? "nil"
+        let statusCode = response.statusCode
+        var log = "------------------- 네트워크 통신 성공 -------------------"
+        log.append("\n3️⃣[\(statusCode)] \(url)\n----------------------------------------------------\n")
+        log.append("response: \n")
+        if let reString = String(bytes: response.data, encoding: String.Encoding.utf8) {
+            log.append("4️⃣\(reString)\n")
+        }
+        log.append("------------------- END HTTP -------------------")
+        print(log)
     }
-    var log = "네트워크 오류"
-      log.append("<-- \(error.errorCode)\n")
-    log.append("\(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
-    log.append("<-- END HTTP")
-    print(log)
-  }
+    
+    func onFail(_ error: MoyaError) {
+        var log = "------------------- 네트워크 오류"
+        log.append("(에러코드: \(error.errorCode)) -------------------\n")
+        log.append("3️⃣ \(error.failureReason ?? error.errorDescription ?? "unknown error")\n")
+        log.append("------------------- END HTTP -------------------")
+        print(log)
+        
+        let alertViewController = UIAlertController(title: "네트워크 연결 실패", message: "네트워크 환경을 한번 더 확인해주세요.", preferredStyle: .alert)
+        alertViewController.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+
+        viewController.present(alertViewController, animated: true)
+    }
 }

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Room/RoomAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Room/RoomAPI.swift
@@ -10,11 +10,11 @@ import Foundation
 import Moya
 
 public class RoomAPI {
+    var roomProvider: MoyaProvider<RoomService>
     
-    static let shared = RoomAPI()
-    var roomProvider = MoyaProvider<RoomService>(plugins: [MoyaLoggerPlugin()])
-    
-    public init() { }
+    public init(viewController: UIViewController) {
+        roomProvider = MoyaProvider<RoomService>(plugins: [MoyaLoggerPlugin(viewController: viewController)])
+    }
 
     func waitingFetch(roomID: Int, completion: @escaping(NetworkResult<Any>) -> Void) {
         roomProvider.request(.waitingFetch(roomID: roomID)) { result in

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/User/UserAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/User/UserAPI.swift
@@ -10,10 +10,11 @@ import Foundation
 import Moya
 
 public class UserAPI {
-    static let shared = UserAPI()
-    var userProvider = MoyaProvider<UserService>(plugins: [MoyaLoggerPlugin()])
+    var userProvider: MoyaProvider<UserService>
     
-    private init() { }
+    public init(viewController: UIViewController) {
+        userProvider = MoyaProvider<UserService>(plugins: [MoyaLoggerPlugin(viewController: viewController)])
+    }
     
     func profileFetch(completion: @escaping(NetworkResult<Any>) -> Void) {
         userProvider.request(.profileFetch) { result in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -403,7 +403,7 @@ extension AuthUploadVC {
 
 extension AuthUploadVC {
     func authUploadWithAPI() {
-        RoomAPI.shared.authUpload(roomID: roomId ?? 0, timer: timerLabel.text ?? "", image: uploadImageView.image ?? UIImage()) {  response in
+        RoomAPI(viewController: self).authUpload(roomID: roomId ?? 0, timer: timerLabel.text ?? "", image: uploadImageView.image ?? UIImage()) {  response in
             switch response {
             case .success(let data):
                 if let authUpload = data as? AuthUpload {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/CodeJoinVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/CodeJoinVC.swift
@@ -183,7 +183,7 @@ extension CodeJoinVC: UITextFieldDelegate {
 
 extension CodeJoinVC {
     func codeJoinCheckFetchWithAPI() {
-        RoomAPI.shared.codeJoinCheckFetch(code: textField.text ?? "") {  response in
+        RoomAPI(viewController: self).codeJoinCheckFetch(code: textField.text ?? "") {  response in
             switch response {
             case .success(let data):
                 if let codeWaiting = data as? CodeWaiting {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
@@ -97,7 +97,7 @@ extension JoinCheckVC {
 
 extension JoinCheckVC {
     func enterRoomWithAPI(roomID: Int) {
-        RoomAPI.shared.enterRoom(roomID: roomID) {  response in
+        RoomAPI(viewController: self).enterRoom(roomID: roomID) {  response in
             switch response {
             case .success(let message):
                 let nextSB = UIStoryboard.init(name: Const.Storyboard.Name.waiting, bundle: nil)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -133,7 +133,7 @@ class CreateAuthVC: UIViewController {
 extension CreateAuthVC {
     func postCreateRoomWithAPI(roomName: String, fromStart: Bool, completion: @escaping () -> Void) {
         let createRoomRequest = CreateRoom(roomName: roomName, fromStart: fromStart)
-        RoomAPI.shared.createRoom(createRoom: createRoomRequest) { response in
+        RoomAPI(viewController: self).createRoom(createRoom: createRoomRequest) { response in
             switch response {
             case .success(let data):
                 if let createdRoom = data as? RoomId {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -103,7 +103,7 @@ class CreateSuccessVC: UIViewController {
 extension CreateSuccessVC {
     /// 방 코드 복사를 위해 대기방 API 통신
     private func getRoomCodeWithAPI(roomId: Int) {
-        RoomAPI.shared.waitingFetch(roomID: roomId) { response in
+        RoomAPI(viewController: self).waitingFetch(roomID: roomId) { response in
             switch response {
             case .success(let data):
                 if let createSuccess = data as? Waiting {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/CompleteFailDialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/CompleteFailDialogueVC.swift
@@ -167,7 +167,7 @@ extension CompleteFailDialogueVC {
 
 extension CompleteFailDialogueVC {
     private func readRoomWithAPI(completion: @escaping () -> Void) {
-        RoomAPI.shared.readRoom(roomID: roomID ?? -1) { response in
+        RoomAPI(viewController: self).readRoom(roomID: roomID ?? -1) { response in
             switch response {
             case .success(let message):
                 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Feed/FeedReportVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Feed/FeedReportVC.swift
@@ -165,7 +165,7 @@ extension FeedReportVC: UITextViewDelegate {
 
 extension FeedReportVC {
     func postFeedReportWithAPI(content: String) {
-        FeedAPI.shared.postFeedReport(recordID: recordID ?? 0, content: content) { response in
+        FeedAPI(viewController: self).postFeedReport(recordID: recordID ?? 0, content: content) { response in
             switch response {
             case .success:
                 self.navigationController?.popViewController(animated: true)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/GoalWriting/GoalWritingVC.swift
@@ -174,7 +174,7 @@ class GoalWritingVC: UIViewController {
 
 extension GoalWritingVC {
     func setPurposeWithAPI(moment: String, purpose: String) {
-        RoomAPI.shared.setPurpose(roomID: roomId ?? 0, moment: moment, purpose: purpose) { response in
+        RoomAPI(viewController: self).setPurpose(roomID: roomId ?? 0, moment: moment, purpose: purpose) { response in
             switch response {
             case .success(let message):
                 print("setPurposeWithAPI - success: \(message)")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
@@ -185,7 +185,7 @@ extension HabitAuthVC {
 
 extension HabitAuthVC {
     func setConsiderRestWithAPI(statusType: String) {
-        RoomAPI.shared.setConsiderRest(roomID: roomID ?? 0, statusType: statusType) {  response in
+        RoomAPI(viewController: self).setConsiderRest(roomID: roomID ?? 0, statusType: statusType) {  response in
             switch response {
             case .success(let message):
                 NotificationCenter.default.post(name: .updateHabitRoom, object: nil)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -551,7 +551,7 @@ extension HabitRoomVC: UICollectionViewDelegateFlowLayout {
 extension HabitRoomVC {
     /// 습관방 데이터 불러오기
     private func fetchHabitRoomDetailWithAPI(roomID: Int, completion: @escaping () -> Void) {
-        RoomAPI.shared.fetchHabitRoomDetail(roomID: roomID) { response in
+        RoomAPI(viewController: self).fetchHabitRoomDetail(roomID: roomID) { response in
             switch response {
             case .success(let data):
                 self.loadingView.stop()
@@ -577,7 +577,7 @@ extension HabitRoomVC {
     
     /// 습관방 나가기
     private func leaveHabitRoomWithAPI(roomID: Int) {
-        RoomAPI.shared.leaveRoom(roomId: roomID) { response in
+        RoomAPI(viewController: self).leaveRoom(roomId: roomID) { response in
             switch response {
             case .success(let message):
                 self.navigationController?.popViewController(animated: true)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -443,7 +443,7 @@ extension SendSparkVC: UICollectionViewDelegate {
 
 extension SendSparkVC {
     func sendSparkWithAPI(content: String) {
-        RoomAPI.shared.sendSpark(roomID: roomID ?? 0, recordID: recordID ?? 0, content: content) {  response in
+        RoomAPI(viewController: self).sendSpark(roomID: roomID ?? 0, recordID: recordID ?? 0, content: content) {  response in
             switch response {
             case .success:
                 let presentVC = self.presentingViewController

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Login/LoginVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Login/LoginVC.swift
@@ -185,7 +185,7 @@ extension LoginVC: ASAuthorizationControllerDelegate, ASAuthorizationControllerP
 
 extension LoginVC {
     private func loginWithAPI(userID: String) {
-        AuthAPI.shared.login(socialID: userID, fcmToken: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.fcmToken) ?? "") { response in
+        AuthAPI(viewController: self).login(socialID: userID, fcmToken: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.fcmToken) ?? "") { response in
             switch response {
             case .success(let data):
                 if let data = data as? Login {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -234,7 +234,7 @@ extension EditProfileVC: UIImagePickerControllerDelegate, UINavigationController
 extension EditProfileVC {
     private func profileEditWithAPI(profileImage: UIImage?, completion: @escaping (() -> Void)) {
         let nickname = textField.text
-        UserAPI.shared.profileEdit(profileImage: profileImage, nickname: nickname ?? "") { response in
+        UserAPI(viewController: self).profileEdit(profileImage: profileImage, nickname: nickname ?? "") { response in
             switch response {
             case .success(let message):
                 completion()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -301,7 +301,7 @@ extension MypageVC: UITableViewDataSource {
 
 extension MypageVC {
     private func profileFetchWithAPI() {
-        UserAPI.shared.profileFetch { response in
+        UserAPI(viewController: self).profileFetch { response in
             switch response {
             case .success(let data):
                 if let profile = data as? Profile {
@@ -325,7 +325,7 @@ extension MypageVC {
     }
     
     private func signoutWithAPI(completion: @escaping () -> Void) {
-        AuthAPI.shared.signout { response in
+        AuthAPI(viewController: self).signout { response in
             switch response {
             case .success(let message):
                 completion()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/NotificationVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/NotificationVC.swift
@@ -169,7 +169,7 @@ extension NotificationVC: UITableViewDataSource {
 
 extension NotificationVC {
     private func settingFetchWithAPI() {
-        NoticeAPI.shared.settingFetch { response in
+        NoticeAPI(viewController: self).settingFetch { response in
             switch response {
             case .success(let data):
                 if let noticeSetting = data as? NoticeSetting {
@@ -190,7 +190,7 @@ extension NotificationVC {
     }
     
     private func settingPatchWithAPI(category: String) {
-        NoticeAPI.shared.settingPatch(category: category) { response in
+        NoticeAPI(viewController: self).settingPatch(category: category) { response in
             switch response {
             case .success(let data):
                 if let noticeSetting = data as? NoticeSetting {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/WithdrawalVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/WithdrawalVC.swift
@@ -152,7 +152,7 @@ extension WithdrawalVC {
 
 extension WithdrawalVC {
     private func withdrawalWithAPI(completion: @escaping () -> Void) {
-        AuthAPI.shared.withdrawal { response in
+        AuthAPI(viewController: self).withdrawal { response in
             switch response {
             case .success(let message):
                 completion()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -337,7 +337,7 @@ extension NoticeVC: UICollectionViewDelegateFlowLayout {
 
 extension NoticeVC {
     private func getActiveNoticeFetchWithAPI(lastID: Int, completion: @escaping() -> Void) {
-        NoticeAPI.shared.activeFetch(lastID: lastID, size: activeCountSize) { response in
+        NoticeAPI(viewController: self).activeFetch(lastID: lastID, size: activeCountSize) { response in
             switch response {
             case .success(let data):
                 if let active = data as? ActiveNotice {
@@ -365,7 +365,7 @@ extension NoticeVC {
     }
     
     private func getServiceNoticeFetchWithAPI(lastID: Int, completion: @escaping() -> Void) {
-        NoticeAPI.shared.serviceFetch(lastID: lastID, size: serviceCountSize) { response in
+        NoticeAPI(viewController: self).serviceFetch(lastID: lastID, size: serviceCountSize) { response in
             switch response {
             case .success(let data):
                 if let service = data as? ServiceNotice {
@@ -393,7 +393,7 @@ extension NoticeVC {
     }
     
     func activeReadWithAPI() {
-        NoticeAPI.shared.activeRead { response in
+        NoticeAPI(viewController: self).activeRead { response in
             switch response {
             case .success(let message):
                 print("activeReadWithAPI - success: \(message)")
@@ -410,7 +410,7 @@ extension NoticeVC {
     }
     
     func serviceReadWithAPI() {
-        NoticeAPI.shared.serviceRead { response in
+        NoticeAPI(viewController: self).serviceRead { response in
             switch response {
             case .success(let message):
                 print("serviceReadWithAPI - success: \(message)")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -280,7 +280,7 @@ extension ProfileSettingVC {
         } else {
             socialID = "Kakao@\(UserDefaults.standard.string(forKey: Const.UserDefaultsKey.userID) ?? "")"
         }
-        AuthAPI.shared.signup(socialID: socialID,
+        AuthAPI(viewController: self).signup(socialID: socialID,
                               profileImg: profileImg,
                               nickname: nickname,
                               fcmToken: UserDefaults.standard.string(forKey: Const.UserDefaultsKey.fcmToken) ?? "") { response in

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
@@ -132,7 +132,7 @@ extension SplashVC {
         let socialID = isAppleLogin ? "Apple@\(userID)" : "Kakao@\(userID)"
         let fcmToken = UserDefaults.standard.string(forKey: Const.UserDefaultsKey.fcmToken) ?? ""
         
-        AuthAPI.shared.login(socialID: socialID, fcmToken: fcmToken) { response in
+        AuthAPI(viewController: self).login(socialID: socialID, fcmToken: fcmToken) { response in
             switch response {
             case .success(let data):
                 if let data = data as? Login {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -55,8 +55,8 @@ class StorageMoreVC: UIViewController {
         setLayout()
         
         DispatchQueue.main.async { [self] in
-            self.getMyRoomCertiWithAPI(lastID: myRoomCertificationLastID, size: myRoomCountSize) {
-                storageMoreCV.reloadData()
+            self.getMyRoomCertiWithAPI(lastID: myRoomCertificationLastID, size: myRoomCountSize) { [self] in
+                self.storageMoreCV.reloadData()
             }
         }
     }
@@ -262,11 +262,11 @@ extension StorageMoreVC: UICollectionViewDataSource {
 
 extension StorageMoreVC {
     func getMyRoomCertiWithAPI(lastID: Int, size: Int, completion: @escaping () -> Void) {
-        MyRoomAPI.shared.myRoomCertiFetch(roomID: roomID ?? 0, lastID: lastID, size: size) {  response in
+        MyRoomAPI(viewController: self).myRoomCertiFetch(roomID: roomID ?? 0, lastID: lastID, size: size) {  response in
             switch response {
             case .success(let data):
                 if let myRoomCerti = data as? MyRoomCertification {
-                    if (self.isChangingImageView) {
+                    if self.isChangingImageView {
                         let filteredData = myRoomCerti.records?.filter({ $0.status == "DONE" })
                         self.myRoomCertificationList?.append(contentsOf: filteredData ?? [])
                     } else {
@@ -288,7 +288,7 @@ extension StorageMoreVC {
     }
     
     func myRoomChangeThumbnailWithAPI(roomId: Int, recordId: Int) {
-        MyRoomAPI.shared.myRoomChangeThumbnail(roomId: roomId, recordId: recordId) {  response in
+        MyRoomAPI(viewController: self).myRoomChangeThumbnail(roomId: roomId, recordId: recordId) {  response in
             switch response {
             case .success:
                 self.dismiss(animated: true) {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -56,7 +56,7 @@ class StorageMoreVC: UIViewController {
         
         DispatchQueue.main.async { [self] in
             self.getMyRoomCertiWithAPI(lastID: myRoomCertificationLastID, size: myRoomCountSize) { [self] in
-                self.storageMoreCV.reloadData()
+                storageMoreCV.reloadData()
             }
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -292,7 +292,7 @@ extension FeedVC {
 
 extension FeedVC {
     private func getFeedListFetchWithAPI(lastID: Int, completion: @escaping() -> Void) {
-        FeedAPI.shared.feedFetch(lastID: lastID, size: feedCountSize) { response in
+        FeedAPI(viewController: self).feedFetch(lastID: lastID, size: feedCountSize) { response in
             
             switch response {
             case .success(let data):
@@ -325,7 +325,7 @@ extension FeedVC {
     }
     
     private func postFeedLikeWithAPI(recordID: Int) {
-        FeedAPI.shared.feedLike(recordID: recordID) { response in
+        FeedAPI(viewController: self).feedLike(recordID: recordID) { response in
             switch response {
             case .success(let message):
                 print("feedLikeWithAPI - success: \(message)")

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -451,7 +451,7 @@ extension HomeVC: UICollectionViewDelegateFlowLayout {
 
 extension HomeVC {
     private func habitRoomFetchWithAPI(lastID: Int, completion: @escaping () -> Void) {
-        HomeAPI.shared.habitRoomFetch(lastID: lastID, size: habitRoomCountSize) { response in
+        HomeAPI(viewController: self).habitRoomFetch(lastID: lastID, size: habitRoomCountSize) { response in
             switch response {
             case .success(let data):
                 self.loadingView.stop()
@@ -481,7 +481,7 @@ extension HomeVC {
     }
     
     private func newNoticeFetchWithAPI(completion: @escaping () -> Void) {
-        NoticeAPI.shared.newNoticeFetch { response in
+        NoticeAPI(viewController: self).newNoticeFetch { response in
             switch response {
             case .success(let data):
                 if let newNotice = data as? NewNotice {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
@@ -587,7 +587,7 @@ extension StorageVC: UICollectionViewDelegate, UICollectionViewDataSource {
 extension StorageVC {
     
     func getOnGoingRoomWithAPI(lastID: Int, size: Int, completion: @escaping () -> Void) {
-        MyRoomAPI.shared.myRoomFetch(roomType: "ONGOING", lastID: lastID, size: size) {  response in
+        MyRoomAPI(viewController: self).myRoomFetch(roomType: "ONGOING", lastID: lastID, size: size) {  response in
             switch response {
             case .success(let data):
                 if let myRoom = data as? MyRoom {
@@ -616,7 +616,7 @@ extension StorageVC {
     }
     
     func getFailRoomWithAPI(lastID: Int, size: Int, completion: @escaping () -> Void) {
-        MyRoomAPI.shared.myRoomFetch(roomType: "FAIL", lastID: lastID, size: size) {  response in
+        MyRoomAPI(viewController: self).myRoomFetch(roomType: "FAIL", lastID: lastID, size: size) {  response in
             switch response {
             case .success(let data):
                 if let myRoom = data as? MyRoom {
@@ -637,7 +637,7 @@ extension StorageVC {
     }
     
     func getCompleteRoomWithAPI(lastID: Int, size: Int, completion: @escaping () -> Void) {
-        MyRoomAPI.shared.myRoomFetch(roomType: "COMPLETE", lastID: lastID, size: size) {  response in
+        MyRoomAPI(viewController: self).myRoomFetch(roomType: "COMPLETE", lastID: lastID, size: size) {  response in
             switch response {
             case .success(let data):
                 if let myRoom = data as? MyRoom {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/RoomStartVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/RoomStartVC.swift
@@ -100,7 +100,7 @@ class RoomStartVC: UIViewController {
 
 extension RoomStartVC {
     private func postStartRoomWithAPI(roomID: Int, completion: @escaping () -> Void) {
-        RoomAPI.shared.startRoomWithAPI(roomID: roomID) { response in
+        RoomAPI(viewController: self).startRoomWithAPI(roomID: roomID) { response in
             switch response {
             case .success(let message):
                 self.startSuccess = true

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -511,7 +511,7 @@ extension WaitingVC {
 
 extension WaitingVC {
     private func getWaitingRoomWithAPI(roomID: Int) {
-        RoomAPI.shared.waitingFetch(roomID: roomID) { response in
+        RoomAPI(viewController: self).waitingFetch(roomID: roomID) { response in
             switch response {
             case .success(let data):
                 self.stopLoadingAnimation()
@@ -533,7 +533,7 @@ extension WaitingVC {
     }
     
     private func getWaitingMembersWithAPI(roomID: Int) {
-        RoomAPI.shared.waitingMemberFetch(roomID: roomID) { response in
+        RoomAPI(viewController: self).waitingMemberFetch(roomID: roomID) { response in
             switch response {
             case .success(let data):
                 if let waitingMembers = data as? WaitingMember {
@@ -554,7 +554,7 @@ extension WaitingVC {
     
     /// 대기방 삭제 API (방장)
     private func deleteWaitingRoomWithAPI(roomID: Int) {
-        RoomAPI.shared.deleteWaitingRoom(roomId: roomID) { response in
+        RoomAPI(viewController: self).deleteWaitingRoom(roomId: roomID) { response in
             switch response {
             case .success(let message):
                 switch self.fromWhereStatus {
@@ -584,7 +584,7 @@ extension WaitingVC {
     
     /// 대기방 나가기 API (참여자)
     private func leaveWaitingRoomWithAPI(roomID: Int) {
-        RoomAPI.shared.leaveRoom(roomId: roomID) { response in
+        RoomAPI(viewController: self).leaveRoom(roomId: roomID) { response in
             switch response {
             case .success(let message):
                 switch self.fromWhereStatus {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#458

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- plugin 의 log 를 찍는 인터페이스를 좀 더 개선했습니다.
- plugin 에서 해당 뷰컨의 객체를 알아야 alert뷰컨을 띄울 수 있었습니다. 그래서 plugin 에 변수를 만들고 각 서버통신의 API 파일에서 moya provider 을 초기화 할때 사용할 뷰컨트롤러 변수 또한 선언했습니다.
- 기존에는 shared 타입 프로퍼티를 사용한 싱글톤 패턴을 사용했지만 각 뷰컨에 대한 정보가 매번 다르기 때문에 싱글톤 패턴에서 변경하게 되었습니다.
> 참고: https://github.com/Moya/Moya/blob/master/docs/Examples/CustomPlugin.md 

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 카카오톡에서 토큰을 확인하는데 네트워크가 손실되면이 부분에서 토큰이 확인되지 않아 AppDelegate 의 isLogin 변수가 false 가 되어서 로그인뷰로 보내는 점을 확인했습니다.(애플도 마찬가지)그래서 네트워크 환경이 좋지 않은 경우에 이런 플로우가 진행됨을 확인했습니다.

- 아래의 코드를 삭제했습니다.
```swift
if let response = error.response {
  onSuceed(response)
  return
}
```
지운 이유는 네트워크의 오류에는 error.response 가 nil 이었기때문에 다시금 onSucceed 를 호출할 일이 없었습니다.
기존에 제가 가져온 코드에서는 response 가 있는 경우에 onSucceed 메서드를 호출해서 그 안에 error 의 response 를 출력하는 인터페이스 구조였는데  로그를 찍을때마다 response 가 있는 경우를 보지 못해서 해당 로직은 삭제했습니다. 

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|네트워크 오류|<img src = "https://user-images.githubusercontent.com/69136340/163526676-24a451f9-b240-4980-9b38-88f9d300f58d.png" width ="250">|
> 더 좋은 문구가 있다면 추천 받아여~

## 📟 관련 이슈
- Resolved: #458
