### PR TITLE
[Feat] #511 - 현재 앱 버전 확인 후 최신 업데이트 안내

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Constants/URL.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/URL.swift
@@ -14,5 +14,7 @@ extension Const {
         static let openSourceLibraryURL = "https://jealous-supernova-274.notion.site/iOS-882534821de74d1cb55bbac8d79fce53"
         static let termsOfUse = "https://jealous-supernova-274.notion.site/39b4b86a458744499baf01d8f6e66c8a"
         static let privatePolicy = "https://jealous-supernova-274.notion.site/e708c2890590404f921b3d8b06f9a705"
+        static let itunesURL = "https://itunes.apple.com/lookup?bundleId="
+        static let appStoreURLScheme = "itms-apps://itunes.apple.com/app/1605811861"
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -46,10 +46,6 @@ class HomeVC: UIViewController {
         registerXib()
         initRefreshControl()
         setNotification()
-        
-        if checkUpdateAvailable() {
-            presentUpdateAlertVC()
-        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -223,39 +219,6 @@ extension HomeVC {
         NotificationCenter.default.addObserver(self, selector: #selector(setToastMessage(_:)), name: .leaveRoom, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateHome), name: .updateHome, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(enterHabitRoomVC(_:)), name: .startHabitRoom, object: nil)
-    }
-    
-    private func checkUpdateAvailable() -> Bool {
-        guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
-              let bundleID = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String,
-              let url = URL(string: Const.URL.itunesURL + bundleID),
-              let data = try? Data(contentsOf: url),
-              let jsonData = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any],
-              let results = jsonData["results"] as? [[String: Any]],
-              results.count > 0,
-              let appStoreVersion = results[0]["version"] as? String else { return false }
-        
-        let currentVersionArray = currentVersion.split(separator: ".").map { $0 }
-        let appStoreVersionArray = appStoreVersion.split(separator: ".").map { $0 }
-        
-        if currentVersionArray[0] < appStoreVersionArray[0] {
-            return true
-        } else {
-            return currentVersionArray[1] < appStoreVersionArray[1] ? true : false
-        }
-    }
-    
-    private func presentUpdateAlertVC() {
-        let alertVC = UIAlertController(title: "업데이트", message: "업데이트가 필요합니다.", preferredStyle: .alert)
-        let alertAtion = UIAlertAction(title: "업데이트", style: .default) { _ in
-            guard let url = URL(string: Const.URL.appStoreURLScheme) else { return }
-            if UIApplication.shared.canOpenURL(url) {
-                UIApplication.shared.open(url)
-            }
-        }
-        alertVC.addAction(alertAtion)
-        
-        present(alertVC, animated: true)
     }
     
     // MARK: - Screen Change


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#511

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 현재 앱 버전과 https://itunes.apple.com/lookup?bundleId=(번들아이디) 의 JSON 중 results 의 version 을 비교해서 업데이트 alert 창을 띄우도록 했습니다.
- 현재 a.b.c 버전에 대해서 a 와 b 버전만 비교해서 낮을 경우 업데이트 했습니다.
> 이는 추후에 업데이트 규칙이 정해지면 수정하겠습니다.
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- itms-apps://itunes.apple.com/app/(app store connect 앱정보의 apple id) 을 통해서 URL Scheme 방법으로 앱스토어를 열도록 했습니다.
- 이슈에 관련 참고 자료 출처를 달아두었습니당
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|업데이트|<img src = "https://user-images.githubusercontent.com/69136340/163604401-c7c9c0c3-ee19-4f44-ad11-de5f81d6d501.mp4" width ="250">|

## 📟 관련 이슈
- Resolved: #511
