### PR TITLE
[Feat] #480 - 프로필 설정 및 생성뷰 이모지 키보드 레이아웃 대응

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -190,8 +190,8 @@ extension EditProfileVC {
         guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardY = keyboardFrame.cgRectValue.minY
         let lineViewY = lineView.frame.maxY
-        // 키보드와 lineView 와의 최소 간격 20.
         UIView.animate(withDuration: 0.3) {
+            // 키보드와 lineView 와의 최소 간격 20.
             if (lineViewY + 20) >= keyboardY {
                 // 키보드가 lineView 를 가린다고 판단.
                 let profileImageViewTopConstraints = 128 - (lineViewY + 20 - keyboardY)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -189,18 +189,28 @@ extension EditProfileVC {
     func updateKeyboardFrame(_ notification: Notification) {
         guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardY = keyboardFrame.cgRectValue.minY
-        let lineViewY = lineView.frame.maxY
+        let lineViewMinimumYMargin = lineView.frame.maxY + 20 // 키보드와 lineView 와의 최소 간격 20.
+        let profileImageViewY = profileImageView.frame.minY - customNavigationBar.frame.maxY // 커스텀 네비바로부터 profileImage 의 간격.
+        let profileImageViewDefaultY = 128.0 // 커스텀 네비바와 profileImageView 의 기본 간격.
+
         UIView.animate(withDuration: 0.3) {
-            // 키보드와 lineView 와의 최소 간격 20.
-            if (lineViewY + 20) >= keyboardY {
-                // 키보드가 lineView 를 가린다고 판단.
-                let profileImageViewTopConstraints = 128 - (lineViewY + 20 - keyboardY)
-                self.profileImageView.snp.updateConstraints {
-                    $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewTopConstraints)
+            if keyboardY != UIScreen.main.bounds.height {
+                // 키보드가 올라온다고 판단.
+                let updateProfileImageViewY = profileImageViewY - (lineViewMinimumYMargin - keyboardY)
+                if updateProfileImageViewY > profileImageViewDefaultY {
+                    // 업데이트 될 profileImageView 가 기본 위치보다 아래일때
+                    self.profileImageView.snp.updateConstraints {
+                        $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewDefaultY)
+                    }
+                } else {
+                    self.profileImageView.snp.updateConstraints {
+                        $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(updateProfileImageViewY)
+                    }
                 }
             } else {
+                // 키보드가 내려감.
                 self.profileImageView.snp.updateConstraints {
-                    $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(128)
+                    $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewDefaultY)
                 }
             }
             self.profileImageView.superview?.layoutIfNeeded()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -196,15 +196,15 @@ extension EditProfileVC {
         UIView.animate(withDuration: 0.3) {
             if keyboardY != UIScreen.main.bounds.height {
                 // 키보드가 올라온다고 판단.
-                let updateProfileImageViewY = profileImageViewTopConstraint - (lineViewMinimumYMargin - keyboardY)
-                if updateProfileImageViewY > profileImageViewDefaultTopConstraint {
+                let updatedProfileImageViewTopConstraint = profileImageViewTopConstraint - (lineViewMinimumYMargin - keyboardY)
+                if updatedProfileImageViewTopConstraint > profileImageViewDefaultTopConstraint {
                     // 업데이트 될 profileImageView 가 기본 위치보다 아래일때
                     self.profileImageView.snp.updateConstraints {
                         $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewDefaultTopConstraint)
                     }
                 } else {
                     self.profileImageView.snp.updateConstraints {
-                        $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(updateProfileImageViewY)
+                        $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(updatedProfileImageViewTopConstraint)
                     }
                 }
             } else {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -189,7 +189,7 @@ extension EditProfileVC {
     func updateKeyboardFrame(_ notification: Notification) {
         guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardY = keyboardFrame.cgRectValue.minY
-        let lineViewMinimumYMargin = lineView.frame.maxY + 20 // 키보드와 lineView 와의 최소 간격 20.
+        let lineViewMinimumYMargin = lineView.frame.maxY + 20 // 키보드와 lineView 와의 최소 간격 20 포함.
         let profileImageViewTopConstraint = profileImageView.frame.minY - customNavigationBar.frame.maxY // 커스텀 네비바로부터 profileImage 의 간격.
         let profileImageViewDefaultTopConstraint = 128.0 // 커스텀 네비바와 profileImageView 의 기본 간격.
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -197,8 +197,8 @@ extension EditProfileVC {
             if keyboardY != UIScreen.main.bounds.height {
                 // 키보드가 올라온다고 판단.
                 let updatedProfileImageViewTopConstraint = profileImageViewTopConstraint - (lineViewMinimumYMargin - keyboardY)
-                if updatedProfileImageViewTopConstraint > profileImageViewDefaultTopConstraint {
-                    // 업데이트 될 profileImageView 가 기본 위치보다 아래일때
+                if updatedProfileImageViewTopConstraint >= profileImageViewDefaultTopConstraint {
+                    // 업데이트 될 profileImageView 가 기본 위치보다 아래일때 혹은 동일.
                     self.profileImageView.snp.updateConstraints {
                         $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewDefaultTopConstraint)
                     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -191,16 +191,19 @@ extension EditProfileVC {
         let keyboardY = keyboardFrame.cgRectValue.minY
         let lineViewY = lineView.frame.maxY
         // 키보드와 lineView 와의 최소 간격 20.
-        if (lineViewY + 20) >= keyboardY {
-            // 키보드가 lineView 를 가린다고 판단.
-            let profileImageViewTopConstraints = 128 - (lineViewY + 20 - keyboardY)
-            profileImageView.snp.updateConstraints {
-                $0.top.equalTo(customNavigationBar.snp.bottom).offset(profileImageViewTopConstraints)
+        UIView.animate(withDuration: 0.3) {
+            if (lineViewY + 20) >= keyboardY {
+                // 키보드가 lineView 를 가린다고 판단.
+                let profileImageViewTopConstraints = 128 - (lineViewY + 20 - keyboardY)
+                self.profileImageView.snp.updateConstraints {
+                    $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewTopConstraints)
+                }
+            } else {
+                self.profileImageView.snp.updateConstraints {
+                    $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(128)
+                }
             }
-        } else {
-            profileImageView.snp.updateConstraints {
-                $0.top.equalTo(customNavigationBar.snp.bottom).offset(128)
-            }
+            self.profileImageView.superview?.layoutIfNeeded()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -190,17 +190,17 @@ extension EditProfileVC {
         guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardY = keyboardFrame.cgRectValue.minY
         let lineViewMinimumYMargin = lineView.frame.maxY + 20 // 키보드와 lineView 와의 최소 간격 20.
-        let profileImageViewY = profileImageView.frame.minY - customNavigationBar.frame.maxY // 커스텀 네비바로부터 profileImage 의 간격.
-        let profileImageViewDefaultY = 128.0 // 커스텀 네비바와 profileImageView 의 기본 간격.
+        let profileImageViewTopConstraint = profileImageView.frame.minY - customNavigationBar.frame.maxY // 커스텀 네비바로부터 profileImage 의 간격.
+        let profileImageViewDefaultTopConstraint = 128.0 // 커스텀 네비바와 profileImageView 의 기본 간격.
 
         UIView.animate(withDuration: 0.3) {
             if keyboardY != UIScreen.main.bounds.height {
                 // 키보드가 올라온다고 판단.
-                let updateProfileImageViewY = profileImageViewY - (lineViewMinimumYMargin - keyboardY)
-                if updateProfileImageViewY > profileImageViewDefaultY {
+                let updateProfileImageViewY = profileImageViewTopConstraint - (lineViewMinimumYMargin - keyboardY)
+                if updateProfileImageViewY > profileImageViewDefaultTopConstraint {
                     // 업데이트 될 profileImageView 가 기본 위치보다 아래일때
                     self.profileImageView.snp.updateConstraints {
-                        $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewDefaultY)
+                        $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewDefaultTopConstraint)
                     }
                 } else {
                     self.profileImageView.snp.updateConstraints {
@@ -210,7 +210,7 @@ extension EditProfileVC {
             } else {
                 // 키보드가 내려감.
                 self.profileImageView.snp.updateConstraints {
-                    $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewDefaultY)
+                    $0.top.equalTo(self.customNavigationBar.snp.bottom).offset(profileImageViewDefaultTopConstraint)
                 }
             }
             self.profileImageView.superview?.layoutIfNeeded()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -101,6 +101,7 @@ extension EditProfileVC {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateKeyboardFrame(_:)), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
     }
     
     private func setAddTarget() {
@@ -110,6 +111,7 @@ extension EditProfileVC {
     
     private func removeObservers() {
         NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
     }
     
     private func openLibrary() {
@@ -181,6 +183,25 @@ extension EditProfileVC {
         }
         profileImageDelegate?.sendProfile(image: profileImageView.image ?? UIImage(named: "profileEmpty")!,
                                           nickname: textField.text ?? "")
+    }
+    
+    @objc
+    func updateKeyboardFrame(_ notification: Notification) {
+        guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        let keyboardY = keyboardFrame.cgRectValue.minY
+        let lineViewY = lineView.frame.maxY
+        // 키보드와 lineView 와의 최소 간격 20.
+        if (lineViewY + 20) >= keyboardY {
+            // 키보드가 lineView 를 가린다고 판단.
+            let profileImageViewTopConstraints = 128 - (lineViewY + 20 - keyboardY)
+            profileImageView.snp.updateConstraints {
+                $0.top.equalTo(customNavigationBar.snp.bottom).offset(profileImageViewTopConstraints)
+            }
+        } else {
+            profileImageView.snp.updateConstraints {
+                $0.top.equalTo(customNavigationBar.snp.bottom).offset(128)
+            }
+        }
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -184,17 +184,20 @@ class ProfileSettingVC: UIViewController {
         guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardY = keyboardFrame.cgRectValue.minY
         let lineViewY = lineView.frame.maxY
-        // 키보드와 lineView 와의 최소 간격 20.
-        if (lineViewY + 20) >= keyboardY {
-            // 키보드가 lineView 를 가린다고 판단.
-            let profileImageViewTopConstraints = 128 - (lineViewY + 20 - keyboardY)
-            profileImageView.snp.updateConstraints {
-                $0.top.equalTo(customNavigationBar.snp.bottom).offset(profileImageViewTopConstraints)
+        UIView.animate(withDuration: 0.3) {
+            // 키보드와 lineView 와의 최소 간격 20.
+            if (lineViewY + 20) >= keyboardY {
+                // 키보드가 lineView 를 가린다고 판단.
+                let profileImageViewTopConstraints = 66 - (lineViewY + 20 - keyboardY)
+                self.profileImageView.snp.updateConstraints {
+                    $0.top.equalTo(self.titleLabel.snp.bottom).offset(profileImageViewTopConstraints)
+                }
+            } else {
+                self.profileImageView.snp.updateConstraints {
+                    $0.top.equalTo(self.titleLabel.snp.bottom).offset(66)
+                }
             }
-        } else {
-            profileImageView.snp.updateConstraints {
-                $0.top.equalTo(customNavigationBar.snp.bottom).offset(128)
-            }
+            self.profileImageView.superview?.layoutIfNeeded()
         }
     }
 }
@@ -264,7 +267,7 @@ extension ProfileSettingVC {
         
         profileImageView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(view.safeAreaLayoutGuide).inset(188)
+            make.top.equalTo(titleLabel.snp.bottom).offset(66)
             make.width.height.equalTo(115)
         }
         

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -201,7 +201,7 @@ class ProfileSettingVC: UIViewController {
                 if  updatedProfileImageViewTopConstraint > profileImageViewDefaultTopConstraint {
                     // 업데이트 될 profileImageView 가 기본 위치보다 아래일때.
                     if lineViewMinimumYMargin == keyboardBeginY {
-                        // 이모지에서 기본 키보드로 변경될때.)
+                        // 이모지 키보드에서 기본 키보드로 변경될때.
                         let keyboardDifferenceY = keyboardEndY - keyboardBeginY
                         let updatedProfileImageViewTopConstraint = profileImageViewTopConstraint + keyboardDifferenceY - ( textFieldDefaultTopConstraint - textFieldTopConstraint)
                         self.profileImageView.snp.updateConstraints {
@@ -211,6 +211,7 @@ class ProfileSettingVC: UIViewController {
                             $0.top.equalTo(self.profileImageView.snp.bottom).offset(textFieldDefaultTopConstraint)
                         }
                     } else {
+                        // 키보드와 lineView 가 최소 간격보다 멀어서 굳이 레이아웃을 대응해주지 않아도 될 때
                         self.profileImageView.snp.updateConstraints {
                             $0.top.equalTo(self.titleLabel.snp.bottom).offset(profileImageViewDefaultTopConstraint)
                         }
@@ -220,7 +221,7 @@ class ProfileSettingVC: UIViewController {
                     }
                 } else {
                     if minimumMargin > updatedProfileImageViewTopConstraint {
-                        // 업데이트 될 profileIma geView 가 titleLabel 보다 높게 위치할때(가릴때)
+                        // 업데이트 될 profileIma geView 가 titleLabel 보다 높게 위치할때(가릴 때)
                         let updatedTextFieldTopConstraint = minimumMargin - updatedProfileImageViewTopConstraint
                         self.profileImageView.snp.updateConstraints {
                             $0.top.equalTo(self.titleLabel.snp.bottom).offset(minimumMargin)
@@ -229,6 +230,7 @@ class ProfileSettingVC: UIViewController {
                             $0.top.equalTo(self.profileImageView.snp.bottom).offset(textFieldTopConstraint - updatedTextFieldTopConstraint)
                         }
                     } else {
+                        // 가리지 않을 때.
                         self.profileImageView.snp.updateConstraints {
                             $0.top.equalTo(self.titleLabel.snp.bottom).offset(updatedProfileImageViewTopConstraint)
                         }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -37,6 +37,12 @@ class ProfileSettingVC: UIViewController {
         setDelegate()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        removeObservers()
+    }
+    
     // MARK: - Methods
     
     private func setUI() {
@@ -76,6 +82,12 @@ class ProfileSettingVC: UIViewController {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateKeyboardFrame(_:)), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+    }
+    
+    private func removeObservers() {
+        NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
     }
     
     private func setAddTarget() {
@@ -165,6 +177,25 @@ class ProfileSettingVC: UIViewController {
     func touchCloseButton() {
         NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
         dismiss(animated: true, completion: nil)
+    }
+    
+    @objc
+    func updateKeyboardFrame(_ notification: Notification) {
+        guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        let keyboardY = keyboardFrame.cgRectValue.minY
+        let lineViewY = lineView.frame.maxY
+        // 키보드와 lineView 와의 최소 간격 20.
+        if (lineViewY + 20) >= keyboardY {
+            // 키보드가 lineView 를 가린다고 판단.
+            let profileImageViewTopConstraints = 128 - (lineViewY + 20 - keyboardY)
+            profileImageView.snp.updateConstraints {
+                $0.top.equalTo(customNavigationBar.snp.bottom).offset(profileImageViewTopConstraints)
+            }
+        } else {
+            profileImageView.snp.updateConstraints {
+                $0.top.equalTo(customNavigationBar.snp.bottom).offset(128)
+            }
+        }
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -193,6 +193,7 @@ class ProfileSettingVC: UIViewController {
                 let updatedProfileImageViewTopConstraint = profileImageViewTopConstraint - (lineViewMinimumYMargin - keyboardY)
                 if updatedProfileImageViewTopConstraint > profileImageViewDefaultTopConstraint {
                     // 업데이트 될 profileImageView 가 기본 위치보다 아래일때
+                if  updatedProfileImageViewTopConstraint >= profileImageViewDefaultTopConstraint {
                     self.profileImageView.snp.updateConstraints {
                         $0.top.equalTo(self.titleLabel.snp.bottom).offset(profileImageViewDefaultTopConstraint)
                     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -183,18 +183,28 @@ class ProfileSettingVC: UIViewController {
     func updateKeyboardFrame(_ notification: Notification) {
         guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardY = keyboardFrame.cgRectValue.minY
-        let lineViewY = lineView.frame.maxY
+        let lineViewMinimumYMargin = lineView.frame.maxY + 20 // 키보드와 lineView 와의 최소 간격 20.
+        let profileImageViewTopConstraint = profileImageView.frame.minY - titleLabel.frame.maxY // titleLabel 로부터 profileImage 의 간격.
+        let profileImageViewDefaultTopConstraint = 66.0 // titleLabel 과 profileImageView 의 기본 간격.
+        
         UIView.animate(withDuration: 0.3) {
-            // 키보드와 lineView 와의 최소 간격 20.
-            if (lineViewY + 20) >= keyboardY {
-                // 키보드가 lineView 를 가린다고 판단.
-                let profileImageViewTopConstraints = 66 - (lineViewY + 20 - keyboardY)
-                self.profileImageView.snp.updateConstraints {
-                    $0.top.equalTo(self.titleLabel.snp.bottom).offset(profileImageViewTopConstraints)
+            if keyboardY != UIScreen.main.bounds.height {
+                // 키보드가 올라온다고 판단.
+                let updatedProfileImageViewTopConstraint = profileImageViewTopConstraint - (lineViewMinimumYMargin - keyboardY)
+                if updatedProfileImageViewTopConstraint > profileImageViewDefaultTopConstraint {
+                    // 업데이트 될 profileImageView 가 기본 위치보다 아래일때
+                    self.profileImageView.snp.updateConstraints {
+                        $0.top.equalTo(self.titleLabel.snp.bottom).offset(profileImageViewDefaultTopConstraint)
+                    }
+                } else {
+                    self.profileImageView.snp.updateConstraints {
+                        $0.top.equalTo(self.titleLabel.snp.bottom).offset(updatedProfileImageViewTopConstraint)
+                    }
                 }
             } else {
+                // 키보드가 내려감.
                 self.profileImageView.snp.updateConstraints {
-                    $0.top.equalTo(self.titleLabel.snp.bottom).offset(66)
+                    $0.top.equalTo(self.titleLabel.snp.bottom).offset(profileImageViewDefaultTopConstraint)
                 }
             }
             self.profileImageView.superview?.layoutIfNeeded()


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#480

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- `keyboardWillChangeFrameNotification` 을 통해서 키보드 프레임이 변경될 때 키보드가 가리는지 가리지 않는지 여부를 판단해서 `profileImageView` 의 top constraint 를 업데이트 하는 로직으로 구성했습니다.

``` swift
// keyboardWillChangeFrameNotification - Posted immediately prior to a change in the keyboard’s frame.
NotificationCenter.default.addObserver(self, selector: #selector(updateKeyboardFrame(_:)), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
```

- 프로필 설정 뷰에서는 titleLabel 까지 침범하는 경우가 있어 이부분은 프로필 설정뷰에서만 대응해주었습니다.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 시뮬에서는 입력하기만 해도 `keyboardWillChangeFrameNotification` 가 post 되서 이상한대 실기기에서는 안그러더라구요. 참고해주세용.

- 키보드가 올라와도 line view 를 가리지 않아서 line view 가 키보드에 붙는 상황도 있었는데 대응해줌.
<img src = "https://user-images.githubusercontent.com/69136340/163706770-02157df0-80bd-4bee-8470-b78c4c3d3627.MP4" width ="250">

- 프로필 설정 시 이모지 키보드에서 프로필 사진이 넘어가는 것도 대응해줌.

> 커밋하고 몇번이나 고쳐서 최종 코드를 보시는게.. 좀 더 눈에 편하실겁니당.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|프로필 설정(SE3)|<img src = "https://user-images.githubusercontent.com/69136340/163717372-62ffa4bf-b5e3-4603-9ccf-ee4947a4b4f5.mp4" width ="250">|
|프로필 수정(13mini)|<img src = "https://user-images.githubusercontent.com/69136340/163706773-8680d13d-1a96-4044-93af-475c036df5d5.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #480
