### PR TITLE
[Feat] #525 - RxSwift, Rxocoa pod install 및 throttle로 알림뷰 버튼 중복 탭 막음

### DIFF
--- a/Spark-iOS/Podfile
+++ b/Spark-iOS/Podfile
@@ -18,4 +18,6 @@ target 'Spark-iOS' do
   pod 'Firebase/Messaging'
   pod 'lottie-ios'
   pod 'Kingfisher', '~> 7.0'
+  pod 'RxSwift', '6.5.0'
+  pod 'RxCocoa', '6.5.0'
 end

--- a/Spark-iOS/Podfile.lock
+++ b/Spark-iOS/Podfile.lock
@@ -1,75 +1,75 @@
 PODS:
-  - Alamofire (5.4.4)
-  - Firebase/Analytics (8.10.0):
+  - Alamofire (5.6.1)
+  - Firebase/Analytics (8.15.0):
     - Firebase/Core
-  - Firebase/Core (8.10.0):
+  - Firebase/Core (8.15.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.10.0)
-  - Firebase/CoreOnly (8.10.0):
-    - FirebaseCore (= 8.10.0)
-  - Firebase/Messaging (8.10.0):
+    - FirebaseAnalytics (~> 8.15.0)
+  - Firebase/CoreOnly (8.15.0):
+    - FirebaseCore (= 8.15.0)
+  - Firebase/Messaging (8.15.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.10.0)
-  - FirebaseAnalytics (8.10.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.10.0)
+    - FirebaseMessaging (~> 8.15.0)
+  - FirebaseAnalytics (8.15.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.15.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.10.0):
+  - FirebaseAnalytics/AdIdSupport (8.15.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.10.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - GoogleAppMeasurement (= 8.15.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - FirebaseCore (8.10.0):
+  - FirebaseCore (8.15.0):
     - FirebaseCoreDiagnostics (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/Logger (~> 7.6)
-  - FirebaseCoreDiagnostics (8.10.0):
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
+  - FirebaseCoreDiagnostics (8.15.0):
     - GoogleDataTransport (~> 9.1)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/Logger (~> 7.6)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.10.0):
+  - FirebaseInstallations (8.15.0):
     - FirebaseCore (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/UserDefaults (~> 7.6)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.10.0):
+  - FirebaseMessaging (8.15.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/Environment (~> 7.6)
-    - GoogleUtilities/Reachability (~> 7.6)
-    - GoogleUtilities/UserDefaults (~> 7.6)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GoogleUtilities/Reachability (~> 7.7)
+    - GoogleUtilities/UserDefaults (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement (8.10.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.10.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+  - GoogleAppMeasurement (8.15.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.15.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.10.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.10.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+  - GoogleAppMeasurement/AdIdSupport (8.15.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.15.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.10.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
-    - GoogleUtilities/MethodSwizzler (~> 7.6)
-    - GoogleUtilities/Network (~> 7.6)
-    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.15.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/MethodSwizzler (~> 7.7)
+    - GoogleUtilities/Network (~> 7.7)
+    - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
   - GoogleDataTransport (9.1.2):
     - GoogleUtilities/Environment (~> 7.2)
@@ -95,18 +95,18 @@ PODS:
   - GoogleUtilities/UserDefaults (7.7.0):
     - GoogleUtilities/Logger
   - JJFloatingActionButton (2.5.0)
-  - KakaoSDKAuth (2.8.4):
-    - KakaoSDKCommon (= 2.8.4)
-  - KakaoSDKCommon (2.8.4):
-    - KakaoSDKCommon/Common (= 2.8.4)
-    - KakaoSDKCommon/Network (= 2.8.4)
-  - KakaoSDKCommon/Common (2.8.4)
-  - KakaoSDKCommon/Network (2.8.4):
+  - KakaoSDKAuth (2.9.1):
+    - KakaoSDKCommon (= 2.9.1)
+  - KakaoSDKCommon (2.9.1):
+    - KakaoSDKCommon/Common (= 2.9.1)
+    - KakaoSDKCommon/Network (= 2.9.1)
+  - KakaoSDKCommon/Common (2.9.1)
+  - KakaoSDKCommon/Network (2.9.1):
     - Alamofire (~> 5.1)
-    - KakaoSDKCommon/Common (= 2.8.4)
-  - KakaoSDKUser (2.8.4):
-    - KakaoSDKAuth (= 2.8.4)
-  - Kingfisher (7.1.1)
+    - KakaoSDKCommon/Common (= 2.9.1)
+  - KakaoSDKUser (2.9.1):
+    - KakaoSDKAuth (= 2.9.1)
+  - Kingfisher (7.2.1)
   - lottie-ios (3.3.0)
   - Moya (15.0.0):
     - Moya/Core (= 15.0.0)
@@ -117,9 +117,15 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
-  - PromisesObjC (2.0.0)
+  - PromisesObjC (2.1.0)
+  - RxCocoa (6.5.0):
+    - RxRelay (= 6.5.0)
+    - RxSwift (= 6.5.0)
+  - RxRelay (6.5.0):
+    - RxSwift (= 6.5.0)
+  - RxSwift (6.5.0)
   - SnapKit (5.0.1)
-  - SwiftLint (0.45.1)
+  - SwiftLint (0.47.0)
 
 DEPENDENCIES:
   - Firebase/Analytics
@@ -131,6 +137,8 @@ DEPENDENCIES:
   - Kingfisher (~> 7.0)
   - lottie-ios
   - Moya (~> 15.0)
+  - RxCocoa (= 6.5.0)
+  - RxSwift (= 6.5.0)
   - SnapKit (~> 5.0.0)
   - SwiftLint
 
@@ -154,6 +162,9 @@ SPEC REPOS:
     - Moya
     - nanopb
     - PromisesObjC
+    - RxCocoa
+    - RxRelay
+    - RxSwift
     - SnapKit
     - SwiftLint
 
@@ -168,28 +179,31 @@ CHECKOUT OPTIONS:
     :git: https://github.com/TeamSparker/JJFloatingActionButton.git
 
 SPEC CHECKSUMS:
-  Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
-  Firebase: 44213362f1dcc52555b935dc925ed35ac55f1b20
-  FirebaseAnalytics: 319c9b3b1bdd400d60e2f415dff0c5f6959e6760
-  FirebaseCore: 04186597c095da37d90ff9fd3e53bc61a1ff2440
-  FirebaseCoreDiagnostics: 56fb7216d87e0e6ec2feddefa9d8a392fe8b2c18
-  FirebaseInstallations: 830327b45345ffc859eaa9c17bcd5ae893fd5425
-  FirebaseMessaging: b0aeba17332ee1ee610662b4d1e02a86db82f08f
-  GoogleAppMeasurement: a3311dbcf3ea651e5a070fe8559b57c174ada081
+  Alamofire: 87bd8c952f9a4454320fce00d9cc3de57bcadaf5
+  Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
+  FirebaseAnalytics: 7761cbadb00a717d8d0939363eb46041526474fa
+  FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
+  FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
+  FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
+  FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
+  GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   JJFloatingActionButton: fdc3aefb0f28f04d0f988fa25d5fac97028a9ea7
-  KakaoSDKAuth: b9b693995f98b1821ccd22b39d383e1dede5ca45
-  KakaoSDKCommon: 33c9902ee9ce13e9d1cac3549896406229836ff5
-  KakaoSDKUser: d878977e0ba6b365cfeac3b6319cdf4231713bea
-  Kingfisher: f738f9c4a3415823b8e2985d10aa2d6a9f37bc4d
+  KakaoSDKAuth: 8ec514e64f57f405735e92483fdae1cc2830d351
+  KakaoSDKCommon: c4b08131fdba6770a280ffe83916048174f329bf
+  KakaoSDKUser: 3b82c8f4b7bdd8584b296cf91d1be4b4a84102fb
+  Kingfisher: 7c084bebf7d548c623ad41bcf765fb200efed369
   lottie-ios: 6ac74dcc09904798f59b18cb3075c089d76be9ae
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
-  PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
+  PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
+  RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
+  RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
+  RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
-  SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
+  SwiftLint: d41cc46a2ae58ac6d9f26954bc89f1d72e71fdef
 
-PODFILE CHECKSUM: cb90bf3724e3427764b629df69e79cb75d9ce25c
+PODFILE CHECKSUM: c6f26cb086a4c592812d547f9f53a7e99b2107d4
 
 COCOAPODS: 1.11.2

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxSwift
+import RxCocoa
 import SnapKit
 
 class NoticeVC: UIViewController {
@@ -36,6 +38,7 @@ class NoticeVC: UIViewController {
     private var serviceList: [Service] = []
     private var newService: Bool = false
     private var newActive: Bool = false
+    private var disposeBag = DisposeBag()
     
     // MARK: - View Life Cycles
 
@@ -45,8 +48,8 @@ class NoticeVC: UIViewController {
         setUI()
         setLayout()
         setCollectionView()
-        setAddTarget()
         setDelegate()
+        bindButton()
         
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
             self.makeDrawAboveButton(button: self.activeButton)
@@ -144,9 +147,25 @@ class NoticeVC: UIViewController {
         collectionView.dataSource = self
     }
     
-    private func setAddTarget() {
-        activeButton.addTarget(self, action: #selector(touchActiveButton), for: .touchUpInside)
-        serviceButton.addTarget(self, action: #selector(touchServiceButton), for: .touchUpInside)
+//    private func setAddTarget() {
+//        activeButton.addTarget(self, action: #selector(touchActiveButton), for: .touchUpInside)
+//        serviceButton.addTarget(self, action: #selector(touchServiceButton), for: .touchUpInside)
+//    }
+    
+    private func bindButton() {
+        activeButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
+            .subscribe(onNext: {
+                self.touchActiveButton()
+            })
+            .disposed(by: disposeBag)
+
+        serviceButton.rx.tap
+            .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
+            .subscribe(onNext: {
+                self.touchServiceButton()
+            })
+            .disposed(by: disposeBag)
     }
 
     private func popToHomeVC() {
@@ -188,6 +207,7 @@ class NoticeVC: UIViewController {
         
         isActivity = true
         activeLastID = -1
+        activeList.removeAll()
         
         let group = DispatchGroup()
         
@@ -218,6 +238,7 @@ class NoticeVC: UIViewController {
         
         isActivity = false
         serviceLastID = -1
+        serviceList.removeAll()
         
         let group = DispatchGroup()
         


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#525

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- RxSwift, RxCocoa pod install
- throttle로 알림뷰 버튼 중복 탭 막음

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
**두 개의 버튼 각각 처음 버튼을 누른 3초 동안의 탭이 막았습니다.**
- 와다다 연속적인 탭이 안되기 때문에 전에 비해 터지지는 않지만, 버튼이 안먹는다는 느낌이 들기도 해서 시간을 줄이거나 해야되나 싶습니다..
- 시간을 줄일 수록 더 연속적으로 탭이 가능해지기 때문에 터질 가능은 증가합니다..



**debounce가 아닌 throttle을 쓴 이유**
- debounce는 시간을 2초로 설정하면 2초 동안 여러번의 이벤트를 받더라도 딱 한 번의 이벤트를 방출하는 친구입니다.
- 마지막에 한 번의 이벤트를 방출하기 때문에 최초 탭을 하더라고 2초 후 이벤트가 발생합니다
- 그래서 안썼습니다 예..



**하고 시픈 말이 있어**
- 확인해주시면 setAddTarget 등의 주석 삭제하고 머지하겠습니다
- 추가적으로 좀만 더 좋은 중복 방지 방법이 있는지 공부하고 몇 개 더 시도해보고 천천히 머지하겠습니다..




## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|


## 📟 관련 이슈
- Resolved: #525 
