### PR TITLE
[Fix] #544 - 홈에서 리프레쉬할 때 엠티뷰가 등장하는 버그

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -350,7 +350,6 @@ extension FeedVC: UICollectionViewDelegate {
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        // FIXME: - 처음 뷰를 로드했을 떄 scrollViewDidScroll이 두 번 실행됨
         if scrollView.contentOffset.y > 0 && scrollView.contentOffset.y > scrollView.contentSize.height - scrollView.bounds.height {
             // isInfinitiScroll이 true이고, isLastScroll이 false일때 스크롤했을 경우만 feed 통신하도록
             if isInfiniteScroll && !isLastScroll {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -321,7 +321,7 @@ extension HomeVC {
 
 extension HomeVC: UICollectionViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.y > scrollView.contentSize.height - scrollView.bounds.height {
+        if scrollView.contentOffset.y > scrollView.contentSize.height - scrollView.bounds.height, scrollView.contentOffset.y > 0 {
             if isInfiniteScroll {
                 isInfiniteScroll = false
                 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#544

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 아래로 당겨서 리프레쉬할때 스크롤해서 방을 fetch 하는 것과 방을 fetch 하는 중복되는 현상 발생했어요.
- 그래서 스크롤할때 방을 fetch 하던 로직을 아래로 스크롤로 로직을 변경했습니다.
```swift
// 문제의 코드
// 이럴때 대기방이 1개이고, 아래로 당겨서 리프레쉬 할때 contentOffset 은 음수가 되서 해당 블록이 실행되지 않는다고 생각했지만,
// 대기방이 적어서 contentSize.height 가 작고, 스크롤뷰의 높이까지 빼주면 음수보다 더 작아질 수 있는 경우가 있었습니다.
if scrollView.contentOffset.y > scrollView.contentSize.height - scrollView.bounds.height {
```

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 피드에서는... 저번에 고쳤더라구용 그래서 같은 로직을 사용했던 홈에서만 적용해주었습니당.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|해결 전|<img src = "https://user-images.githubusercontent.com/69136340/164167449-5d5b7ca4-b535-488e-b610-f65aab3704cc.mp4" width ="250">|
|해결 후|<img src = "https://user-images.githubusercontent.com/69136340/164167508-f5eb0ba0-2b5c-4176-9c8c-9016374221b4.mp4" width ="250">|

## 📟 관련 이슈
- Resolved: #544
