### PR TITLE
[Fix] #549 - 대기방 개설자 방 삭제 시 토스트메세지 분기처리

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -265,6 +265,8 @@ extension HomeVC {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.4) {
             guard var roomName: String = notification.userInfo?["roomName"] as? String else { return }
             guard let waiting: Bool = notification.userInfo?["waitingRoom"] as? Bool else { return }
+            guard let isHost: Bool = notification.userInfo?["isHost"] as? Bool else { return }
+            
             let message: String
         
             if roomName.count > 8 {
@@ -273,7 +275,7 @@ extension HomeVC {
             }
             
             if waiting {
-                message = "'\(roomName)' 대기방을 나갔어요."
+                message = isHost ? "'\(roomName)' 대기방을 삭제했어요." : "'\(roomName)' 대기방을 나갔어요."
             } else {
                 message = "'\(roomName)' 방을 나갔어요."
             }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -499,7 +499,7 @@ extension WaitingVC {
     }
     
     private func postLeaveNotification() {
-        NotificationCenter.default.post(name: .leaveRoom, object: nil, userInfo: ["roomName": "\(roomName ?? "")", "waitingRoom": true])
+        NotificationCenter.default.post(name: .leaveRoom, object: nil, userInfo: ["roomName": "\(roomName ?? "")", "waitingRoom": true, "isHost": isHost ?? false])
     }
     
     private func postStartHabitNotification() {


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#549

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
방 삭제 시 보내는 노티에 isHost 라는 키값을 추가했고 삼항연산자로 homeVC에서 분기처리해줬습니다.



## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
나중에 문구 확정되면 문구만 쇽샥 바꾸겠습니다.


## 📸 스크린샷

https://user-images.githubusercontent.com/81167570/164610392-ac806308-8aef-4781-805d-056825902dda.mov



## 📟 관련 이슈
- Resolved: #549 
