### PR TITLE
[Fix] #539 - 마이페이지에서 기본프로필의 경우 가끔 보이지 않는 버그

### DIFF
--- a/Spark-iOS/Spark-iOS.xcworkspace/contents.xcworkspacedata
+++ b/Spark-iOS/Spark-iOS.xcworkspace/contents.xcworkspacedata
@@ -2,9 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:SingleResponseDialogue.storyboard">
-   </FileRef>
-   <FileRef
       location = "group:Spark-iOS.xcodeproj">
    </FileRef>
    <FileRef

--- a/Spark-iOS/Spark-iOS/Source/Cells/Mypage/MypageProfileTVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/Mypage/MypageProfileTVC.swift
@@ -54,10 +54,23 @@ extension MypageProfileTVC {
         lineView.backgroundColor = .sparkDarkGray
     }
     
-    // initializer.
-    func initCell(profileImage: UIImage?, nickname: String?) {
-        profileImageView.image = profileImage
+    // MARK: - Initializer
+    
+    /// 마이페이지에서 서버통신을 통해 프로필 사진 설정
+    func initCell(profileImageURL: String?, nickname: String?) {
+        guard let profileImageURL = profileImageURL else {
+            profileImageView.image = UIImage(named: "sparkLightGrayPlaceholder")
+            profileNameLabel.text = nickname ?? ""
+            return
+        }
+        profileImageView.updateImage(profileImageURL, type: .small)
         profileNameLabel.text = nickname ?? ""
+    }
+    
+    /// 프로필 수정해서 프로필 사진 설정
+    func initCell(profileImage: UIImage, nickname: String?) {
+        profileImageView.image = profileImage
+        profileNameLabel.text = nickname
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -27,6 +27,7 @@ class EditProfileVC: UIViewController {
     
     weak var profileImageDelegate: ProfileImageDelegate?
     
+    var profileImageURL: String?
     var profileImage: UIImage?
     var nickname: String?
     
@@ -70,7 +71,15 @@ extension EditProfileVC {
                 }
             }
         
-        profileImageView.image = profileImage
+        if let profileImage = profileImage {
+            profileImageView.image = profileImage
+        } else {
+            guard let profileImageURL = profileImageURL else {
+                profileImageView.image = UIImage(named: "profileEmpty")
+                return
+            }
+            profileImageView.updateImage(profileImageURL, type: .small)
+        }
         profileImageView.layer.cornerRadius = 58
         profileImageView.contentMode = .scaleAspectFill
         profileImageView.layer.masksToBounds = true

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/MypageVC.swift
@@ -39,6 +39,7 @@ class MypageVC: UIViewController {
     private let tableView = UITableView(frame: .zero, style: .grouped)
     
     private var profileImage: UIImage?
+    private var profileImageURL: String?
     private var profileNickname: String?
     
     // MARK: - View Life Cycle
@@ -137,8 +138,12 @@ extension MypageVC: UITableViewDelegate {
         switch section {
         case .profile:
             guard let editProfileVC = UIStoryboard(name: Const.Storyboard.Name.editProfile, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.editProfile) as? EditProfileVC else { return }
-
-            editProfileVC.profileImage = profileImage
+            
+            if let profileImage = profileImage {
+                editProfileVC.profileImage = profileImage
+            } else {
+                editProfileVC.profileImageURL = profileImageURL
+            }
             editProfileVC.nickname = profileNickname
             editProfileVC.profileImageDelegate = self
             editProfileVC.modalPresentationStyle = .overFullScreen
@@ -261,7 +266,11 @@ extension MypageVC: UITableViewDataSource {
         switch section {
         case .profile:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: Const.Cell.Identifier.mypageProfileTVC, for: indexPath) as? MypageProfileTVC else { return UITableViewCell()}
-            cell.initCell(profileImage: profileImage, nickname: profileNickname)
+            if let profileImage = profileImage {
+                cell.initCell(profileImage: profileImage, nickname: profileNickname)
+            } else {
+                cell.initCell(profileImageURL: profileImageURL, nickname: profileNickname)
+            }
             cell.selectionStyle = .none
             
             return cell
@@ -306,10 +315,7 @@ extension MypageVC {
             case .success(let data):
                 if let profile = data as? Profile {
                     self.profileNickname = profile.nickname
-                    
-                    let imageView = UIImageView()
-                    imageView.updateImage(profile.profileImage, type: .small)
-                    self.profileImage = imageView.image
+                    self.profileImageURL = profile.profileImage
                     self.tableView.reloadData()
                 }
             case .requestErr(let message):


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#539

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 홈 에서 마이페이지로 갈때는 `profileImage` 가 nil 이기 때문에 서버통신을 통한 URL 을 통해서 프로필 셀과 프로필 수정 뷰로 변수를 전달해준다.
- 프로필 수정에서 마이페이지로 갈때는 `profileImage` 를 델리게이트로 넘겨줘서 로컬에서 변경하도록 했다.
- 서버통신은 마이페이지로 갈때 최초 한번. 프로필 수정에서 완료 버튼을 눌렀을때 작동한다.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 마이페이지 프로필 셀은 초기화 메서드가 두개이다.
  - 서버통신을 통해 얻은 URL 로 초기화
  - 프로필 수정을 통해서 로컬로 이미지를 변경해서 초기화
- profileImage 가 nil 이 아닌 경우는 프로필 변경 후 마이페이지로 돌아올 때이다. 왜냐면 프로토콜로 UIimage 가 전달되어 profileImage 가 nil 이 아닌 것이다. 이때만 로컬로 이미지를 변경해주었다.(프로필을 변경하고 바로 프로필 URL 을 다운로드하면 404 에러가 등장했기 때문)

### 기본 프로필 에셋이 서버와 저희 에셋이 서로 다른거 같아서 슬랙으로 여쭈어봤습니당

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|프로필 변경|<img src = "https://user-images.githubusercontent.com/69136340/164991985-92165cea-b170-4125-be10-072897a88090.mov" width ="250">|

## 📟 관련 이슈
- Resolved: #539




