### PR TITLE
[Feat] #567 - 홈, 습관방에 haptic 추가

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/CompleteFailDialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/CompleteFailDialogueVC.swift
@@ -23,6 +23,8 @@ class CompleteFailDialogueVC: UIViewController {
     private let subtitleLable = UILabel()
     private let button = UIButton()
     
+    private var impactFeedbackGenerator: UIImpactFeedbackGenerator?
+    
     var roomID: Int?
     var roomStatus: RoomStatus?
     
@@ -159,6 +161,10 @@ extension CompleteFailDialogueVC {
     
     @objc
     private func touchButton() {
+        impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
+        impactFeedbackGenerator?.impactOccurred()
+        impactFeedbackGenerator = nil
+        
         dismissCompleteFailDialogueVC()
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/LifeDiminishDialogueVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Dialogue/LifeDiminishDialogueVC.swift
@@ -15,6 +15,8 @@ class LifeDiminishDialogueVC: UIViewController {
     
     var diminishedLifeCount: Int?
     
+    private var impactFeedbackGenerator: UIImpactFeedbackGenerator?
+    
     private let popUpView: UIView = {
         let view = UIView()
         view.backgroundColor = .sparkWhite
@@ -129,6 +131,10 @@ extension LifeDiminishDialogueVC {
     
     @objc
     private func touchButton() {
+        impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
+        impactFeedbackGenerator?.impactOccurred()
+        impactFeedbackGenerator = nil
+        
         self.dismiss(animated: true)
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -24,6 +24,8 @@ class HabitRoomVC: UIViewController {
     private lazy var loadingView = AnimationView(name: Const.Lottie.Name.loading)
     lazy var refreshControl = UIRefreshControl()
     
+    private var impactFeedbackGenerator: UIImpactFeedbackGenerator?
+    
     // MARK: - @IBOutlet Properties
     
     @IBOutlet weak var customNavigationBar: LeftRightButtonsNavigationBar!
@@ -72,6 +74,10 @@ class HabitRoomVC: UIViewController {
     // MARK: - @IBOutlet Action
     
     @IBAction func presentToHabitAuthVC(_ sender: Any) {
+        impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
+        impactFeedbackGenerator?.impactOccurred()
+        impactFeedbackGenerator = nil
+        
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.habitAuth, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.habitAuth) as? HabitAuthVC else { return }
         nextVC.modalTransitionStyle = .crossDissolve
         nextVC.modalPresentationStyle = .overFullScreen

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -33,7 +33,7 @@ class SendSparkVC: UIViewController {
     private var canChangeKeyboardFrame: Bool = false
     private var keyBoardDidHideChecker: Bool = false
     
-    private var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
+    private var impactFeedbackGenerator: UIImpactFeedbackGenerator?
 
     private let customNavigationBar = LeftButtonNavigaitonBar()
     
@@ -157,8 +157,9 @@ extension SendSparkVC {
     }
     
     private func setFeedbackGenerator() {
-        selectionFeedbackGenerator = UISelectionFeedbackGenerator()
-        selectionFeedbackGenerator?.selectionChanged()
+        impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
+        impactFeedbackGenerator?.impactOccurred()
+        impactFeedbackGenerator = nil
     }
     
     private func setAddTargets() {
@@ -456,7 +457,11 @@ extension SendSparkVC: UICollectionViewDataSource {
 // MARK: - UICollectionViewDelegate
 
 extension SendSparkVC: UICollectionViewDelegate {
-
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
+        impactFeedbackGenerator?.impactOccurred()
+        impactFeedbackGenerator = nil
+    }
 }
 
 // MARK: Network


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#567

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 홈 미완료 / 완료 방 팝업 `확인했어요` 버튼에 햅틱 추가
- 습관방 생명 감소 팝업 `확인했어요` 버튼에 햅틱추가
- 습관방 `오늘의 인증` 버튼에 햅틱 추가
- 스파크 보내기 햅틱 효과 강화

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 스파크 보내기 햅틱은 selection 에서 impact 피드백 으로 변경하였습니다.

### Impact
Impact haptics 는 시각적 경험을 보완하는데 사용할 수 있는 물리적 메타포를 제공한다. 예를 들어 사람들은 view 가 제자리에 고정될 때 탭을 느끼거나 두 개의 무거운 물체가 충돌할 때 쿵 소리를 느낄 수 있습니다.

### Selection
Selection haptics 는 UI 요소의 값이 변경되는 동안 피드백을 제공한다.

> 그래서 selection 을 사용했는데 너무 약했네용 그래서 impact 에서 제일 약한 light 를 사용했습니다.

- HIG 문서에서 햅틱을 경험할 수 있습니당~ 
> [HIG - haptic](https://developer.apple.com/design/human-interface-guidelines/ios/user-interaction/haptics/)

## 📟 관련 이슈
- Resolved: #567
