### PR TITLE
[Fix] #577 - 트래킹 이벤트 item name 변경

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Cells/HabitRoom/SendSparkCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/HabitRoom/SendSparkCVC.swift
@@ -64,25 +64,15 @@ extension SendSparkCVC {
     private func tracking(type: SendSparkStatus) {
         switch type {
         case .message:
-            Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-                AnalyticsParameterItemID: Tracking.Select.clickSparkInputText
-            ])
+            Analytics.logEvent(Tracking.Select.clickSparkInputText, parameters: nil)
         case .first:
-            Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-                AnalyticsParameterItemID: Tracking.Select.clickSparkFighting
-            ])
+            Analytics.logEvent(Tracking.Select.clickSparkFighting, parameters: nil)
         case .second:
-            Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-                AnalyticsParameterItemID: Tracking.Select.clickSparkTogether
-            ])
+            Analytics.logEvent(Tracking.Select.clickSparkTogether, parameters: nil)
         case .third:
-            Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-                AnalyticsParameterItemID: Tracking.Select.clickSparkUonly
-            ])
+            Analytics.logEvent(Tracking.Select.clickSparkUonly, parameters: nil)
         case .fourth:
-            Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-                AnalyticsParameterItemID: Tracking.Select.clickSparkHurry
-            ])
+            Analytics.logEvent(Tracking.Select.clickSparkHurry, parameters: nil)
         }
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -235,9 +235,7 @@ extension AuthUploadVC {
     }
     
     private func uploadTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickUpload
-        ])
+        Analytics.logEvent(Tracking.Select.clickUpload, parameters: nil)
     }
     
     // MARK: - @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/CodeJoinVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/CodeJoinVC.swift
@@ -99,9 +99,7 @@ extension CodeJoinVC {
     }
     
     private func okTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickOK
-        ])
+        Analytics.logEvent(Tracking.Select.clickOK, parameters: nil)
     }
     
     // MARK: - @objc Function

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -79,8 +79,7 @@ class CreateAuthVC: UIViewController {
     }
     
     private func createTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickNextCreateRoom,
+        Analytics.logEvent(Tracking.Select.clickNextCreateRoom, parameters: [
             AnalyticsParameterStartDate: self.changeDate()
         ])
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/CompleteAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/CompleteAuthVC.swift
@@ -135,15 +135,11 @@ extension CompleteAuthVC {
     }
     
     private func goToFeedTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-             AnalyticsParameterItemID: Tracking.Select.clickFeed
-         ])
+        Analytics.logEvent(Tracking.Select.clickFeed, parameters: nil)
     }
     
     private func shareTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-             AnalyticsParameterItemID: Tracking.Select.clickShare
-         ])
+        Analytics.logEvent(Tracking.Select.clickShare, parameters: nil)
     }
     
     // MARK: - @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitAuthVC.swift
@@ -136,16 +136,12 @@ extension HabitAuthVC {
     }
     
     private func considerTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickConsider
-        ])
+        Analytics.logEvent(Tracking.Select.clickConsider, parameters: nil)
         
     }
     
     private func okTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickCertifying
-        ])
+        Analytics.logEvent(Tracking.Select.clickCertifying, parameters: nil)
     }
     
     @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -117,9 +117,7 @@ class ProfileSettingVC: UIViewController {
     }
     
     private func tracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickSignup
-        ])
+        Analytics.logEvent(Tracking.Select.clickSignup, parameters: nil)
     }
     
     // MARK: - @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -227,9 +227,7 @@ class FeedVC: UIViewController {
     }
     
     private func heartTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickHeartFeed
-        ])
+        Analytics.logEvent(Tracking.Select.clickHeartFeed, parameters: nil)
     }
     
     // MARK: - @objc Methods

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
@@ -425,9 +425,7 @@ extension StorageVC {
     }
     
     private func cardTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickCard
-        ])
+        Analytics.logEvent(Tracking.Select.clickCard, parameters: nil)
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -163,9 +163,8 @@ extension WaitingVC {
     }
     
     private func startTracking() {
-        Analytics.logEvent(AnalyticsEventSelectItem, parameters: [
-            AnalyticsParameterItemID: Tracking.Select.clickStartHabit,
-            AnalyticsParameterStartDate: changeDate()
+        Analytics.logEvent(Tracking.Select.clickStartHabit, parameters: [
+            AnalyticsParameterStartDate: self.changeDate()
         ])
     }
     


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#577

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 트래킹 이벤트의 이름을 select_item 에서 각 이벤트의 고유한 이름으로 변경해주었습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|수종사항|<img src = "https://user-images.githubusercontent.com/69136340/165753828-6bc7214d-371f-4c66-ac50-714857dec3f4.png" width ="250">|

## 📟 관련 이슈
- Resolved: #577
