### PR TITLE
[Feat] #559 - 프로필 수정 완료 후 로딩뷰 추가

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Mypage/EditProfileVC.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import Lottie
+
 class EditProfileVC: UIViewController {
 
     // MARK: - Properties
@@ -18,9 +20,12 @@ class EditProfileVC: UIViewController {
     private let textField = UITextField()
     private let lineView = UIView()
     private let countLabel = UILabel()
-    private var completeButton = BottomButton().setUI(.pink).setTitle("수정 완료").setAble()
+    private let completeButton = BottomButton().setUI(.pink).setTitle("수정 완료").setAble()
     private let picker = UIImagePickerController()
     private let tap = UITapGestureRecognizer()
+    
+    private lazy var loadingBgView = UIView()
+    private lazy var loadingView = AnimationView(name: Const.Lottie.Name.loading)
     
     private let maxLength: Int = 10
     private var didEdit: Bool = false
@@ -135,6 +140,26 @@ extension EditProfileVC {
         }
     }
     
+    private func setLoading() {
+        view.addSubview(loadingBgView)
+        
+        loadingBgView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        loadingBgView.addSubview(loadingView)
+        
+        loadingView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.equalTo(100)
+        }
+        
+        loadingBgView.backgroundColor = .white.withAlphaComponent(0.8)
+        loadingView.loopMode = .loop
+        loadingView.contentMode = .scaleAspectFit
+        loadingView.play()
+    }
+    
     // MARK: - @objc
     
     @objc
@@ -181,6 +206,7 @@ extension EditProfileVC {
     
     @objc
     func touchCompleteButton() {
+        setLoading()
         if profileImageView.image == UIImage(named: "profileEmpty") {
             profileEditWithAPI(profileImage: nil) {
                 self.dismiss(animated: true, completion: nil)

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Profile/ProfileSettingVC.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import FirebaseAnalytics
+import Lottie
 import SnapKit
 
 class ProfileSettingVC: UIViewController {
@@ -26,6 +27,9 @@ class ProfileSettingVC: UIViewController {
     private let picker = UIImagePickerController()
     private let tap = UITapGestureRecognizer()
     private let maxLength: Int = 10
+    
+    private lazy var loadingBgView = UIView()
+    private lazy var loadingView = AnimationView(name: Const.Lottie.Name.loading)
     
     // MARK: - View Life Cycle
     
@@ -116,6 +120,26 @@ class ProfileSettingVC: UIViewController {
         present(mainVC, animated: true, completion: nil)
     }
     
+    private func setLoading() {
+        view.addSubview(loadingBgView)
+        
+        loadingBgView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        loadingBgView.addSubview(loadingView)
+        
+        loadingView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.equalTo(100)
+        }
+        
+        loadingBgView.backgroundColor = .white.withAlphaComponent(0.8)
+        loadingView.loopMode = .loop
+        loadingView.contentMode = .scaleAspectFit
+        loadingView.play()
+    }
+    
     private func tracking() {
         Analytics.logEvent(Tracking.Select.clickSignup, parameters: nil)
     }
@@ -164,6 +188,7 @@ class ProfileSettingVC: UIViewController {
     
     @objc
     func touchCompleteButton() {
+        setLoading()
         let profileImage = profileImageView.image == UIImage(named: "profileEmpty") ? nil : profileImageView.image?.resize()
         signupWithAPI(profileImage: profileImage, nickname: textField.text ?? "") {
             NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#559

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 프로필 변경
- 프로필 설정(회원가입)
- 두군데에 사진을 업로드하는 시간이 길어져서 사용자에게 사용성을 해치므로 로딩창을 추가했습니다.
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 어차피 화면전환되서 뷰에서 remove 안해주려했는데 앗! 메모리문제가 있으려나~ 했는데 프로필 변경은 dismiss 로 메모리에서 해제되고, 프로필 설정또한 `fullScreen` 으로 화면전환을 해서 `viewDidDisAppear` 되기 때문에 remove 코드는 작성하지 않았습니당!

![스크린샷 2022-04-30 오전 12 39 10](https://user-images.githubusercontent.com/69136340/165977787-3850b84f-4d0d-4d8e-9ad2-033fdece9085.png)

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|프로필 수정 로딩|<img src = "https://user-images.githubusercontent.com/69136340/165977262-c39de0ce-c6fd-4988-8cd5-54cb2fb7e2cc.mov" width ="250">|

## 📟 관련 이슈
- Resolved: #559


