### PR TITLE
[Feat] #582 - 푸시알림으로 앱을 열 경우 트래킹

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Constants/Tracking.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Tracking.swift
@@ -34,4 +34,12 @@ struct Tracking {
         static let clickShare = "click_SHARE_INSTAGRAM"
         static let clickCard = "click_CARD_my_room"
     }
+    
+    struct Notification {
+        static let spark = "notification_open_SPARK"
+        static let certification = "notification_open_CERTIFICATION"
+        static let remind = "notification_open_REMIND"
+        static let roomstart = "notification_open_ROOMSTART"
+        static let consider = "notification_open_CONSIDER"
+    }
 }

--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -83,7 +83,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UNUserNotificationCenter.current().delegate = self
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         UNUserNotificationCenter.current().requestAuthorization(options: authOptions, completionHandler: { _, _ in })
-        application.registerForRemoteNotifications()
         
         // device token 요청.
         UIApplication.shared.registerForRemoteNotifications()

--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -14,6 +14,15 @@ import KakaoSDKAuth
 import KakaoSDKCommon
 import KakaoSDKUser
 
+@frozen
+enum ThreadID: String {
+    case spark = "spark"
+    case certification = "certification"
+    case remind = "remind"
+    case roomStart = "roomStart"
+    case consider = "consider"
+}
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -126,6 +135,21 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo
         // With swizzling disabled you must let Messaging know about the message, for Analytics
         Messaging.messaging().appDidReceiveMessage(userInfo)
+        
+        let notificationThreadID = response.notification.request.content.threadIdentifier
+        guard let threadID = ThreadID(rawValue: notificationThreadID) else { return }
+        switch threadID {
+        case .spark:
+            Analytics.logEvent(Tracking.Notification.spark, parameters: nil)
+        case .certification:
+            Analytics.logEvent(Tracking.Notification.certification, parameters: nil)
+        case .remind:
+            Analytics.logEvent(Tracking.Notification.remind, parameters: nil)
+        case .roomStart:
+            Analytics.logEvent(Tracking.Notification.roomstart, parameters: nil)
+        case .consider:
+            Analytics.logEvent(Tracking.Notification.consider, parameters: nil)
+        }
         
         completionHandler()
     }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#582

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 푸시알림으로 앱을 열 경우 추적
```swift
스파크알림 - spark
인증알림 - certification
리마인드 알림 - remind
습관방 시작 알림 - roomStart
고민중 - consider
```
에 대해서 notification_open_... 로 이벤트 이름 지정했습니다.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 실시간에서는 확인되는데 대시보드에서는 확인이 안되긴하네용... 좀 뒤에 적용되려나 싶네요!
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|트래킹|<img src = "https://user-images.githubusercontent.com/69136340/166100479-9dc5c984-fc68-477d-9b90-9a997b5f61a0.png" width ="250">|

## 📟 관련 이슈
- Resolved: #582
