### PR TITLE
[Fix] #587 - 스파크 보내기 트래킹 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -16,11 +16,11 @@ import KakaoSDKUser
 
 @frozen
 enum ThreadID: String {
-    case spark = "spark"
-    case certification = "certification"
-    case remind = "remind"
-    case roomStart = "roomStart"
-    case consider = "consider"
+    case spark
+    case certification
+    case remind
+    case roomStart
+    case consider
 }
 
 @main

--- a/Spark-iOS/Spark-iOS/Source/Cells/HabitRoom/SendSparkCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/HabitRoom/SendSparkCVC.swift
@@ -68,7 +68,7 @@ extension SendSparkCVC {
         if sender.type == .message {
             sendSparkCellDelegate?.showTextField()
         } else {
-            sendSparkCellDelegate?.sendSpark(with: sender.content ?? "", type: sender.type)
+            sendSparkCellDelegate?.sendSpark(with: sender.content ?? "", type: sender.type ?? .first)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Cells/HabitRoom/SendSparkCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/HabitRoom/SendSparkCVC.swift
@@ -61,21 +61,6 @@ extension SendSparkCVC {
         selectionFeedbackGenerator?.selectionChanged()
     }
     
-    private func tracking(type: SendSparkStatus) {
-        switch type {
-        case .message:
-            Analytics.logEvent(Tracking.Select.clickSparkInputText, parameters: nil)
-        case .first:
-            Analytics.logEvent(Tracking.Select.clickSparkFighting, parameters: nil)
-        case .second:
-            Analytics.logEvent(Tracking.Select.clickSparkTogether, parameters: nil)
-        case .third:
-            Analytics.logEvent(Tracking.Select.clickSparkUonly, parameters: nil)
-        case .fourth:
-            Analytics.logEvent(Tracking.Select.clickSparkHurry, parameters: nil)
-        }
-    }
-    
     // MARK: - @objc Function
     
     @objc
@@ -83,9 +68,7 @@ extension SendSparkCVC {
         if sender.type == .message {
             sendSparkCellDelegate?.showTextField()
         } else {
-            sendSparkCellDelegate?.sendSpark(sender.content ?? "")
+            sendSparkCellDelegate?.sendSpark(with: sender.content ?? "", type: sender.type)
         }
-    
-        tracking(type: sender.type ?? .message)
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/Protocols/SendSparkCellDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/Protocols/SendSparkCellDelegate.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol SendSparkCellDelegate: AnyObject {
-    func sendSpark(_ content: String)
+    func sendSpark(with content: String, type: SendSparkStatus?)
     func showTextField()
 }

--- a/Spark-iOS/Spark-iOS/Source/Protocols/SendSparkCellDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/Protocols/SendSparkCellDelegate.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol SendSparkCellDelegate: AnyObject {
-    func sendSpark(with content: String, type: SendSparkStatus?)
+    func sendSpark(with content: String, type: SendSparkStatus)
     func showTextField()
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import FirebaseAnalytics
 import RxCocoa
 import RxSwift
 
@@ -197,6 +198,7 @@ extension SendSparkVC {
     @objc
     private func sendSparkWithMessage() {
         sendSparkWithAPI(content: textField.text ?? "")
+        Analytics.logEvent(Tracking.Select.clickSparkInputText, parameters: nil)
     }
     
     @objc
@@ -401,8 +403,22 @@ extension SendSparkVC {
 // MARK: - SendSparkCellDelegate
 
 extension SendSparkVC: SendSparkCellDelegate {
-    func sendSpark(_ content: String) {
+    func sendSpark(with content: String, type: SendSparkStatus?) {
         sendSparkButtonTapped.accept(content)
+        
+        guard let type = type else { return }
+        switch type {
+        case .message:
+            Analytics.logEvent(Tracking.Select.clickSparkInputText, parameters: nil)
+        case .first:
+            Analytics.logEvent(Tracking.Select.clickSparkFighting, parameters: nil)
+        case .second:
+            Analytics.logEvent(Tracking.Select.clickSparkTogether, parameters: nil)
+        case .third:
+            Analytics.logEvent(Tracking.Select.clickSparkUonly, parameters: nil)
+        case .fourth:
+            Analytics.logEvent(Tracking.Select.clickSparkHurry, parameters: nil)
+        }
     }
     func showTextField() {
         showAnimation()
@@ -426,6 +442,8 @@ extension SendSparkVC: UITextFieldDelegate {
         }
         hideAnimation()
         self.view.endEditing(true)
+        
+        Analytics.logEvent(Tracking.Select.clickSparkInputText, parameters: nil)
         return true
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -22,7 +22,7 @@ class SendSparkVC: UIViewController {
     
     private let disposeBag = DisposeBag()
     
-    private let sendSparkButtonTapped = PublishRelay<String>()
+    private let sendSparkButtonTapped = PublishRelay<[String: Any]>()
     
     private var maxLength: Int = 15
     private let screenHeight: CGFloat = UIScreen.main.bounds.height
@@ -186,11 +186,25 @@ extension SendSparkVC {
     private func bind() {
         sendSparkButtonTapped
             .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
-            .asDriver(onErrorJustReturn: "")
-            .drive(onNext: { msg in
-                self.sendSparkWithAPI(content: msg)
+            .asDriver(onErrorJustReturn: ["": ""])
+            .drive(onNext: { dictionary in
+                guard let content = dictionary["content"] as? String, let type = dictionary["type"] as? SendSparkStatus else { return }
+                
+                self.sendSparkWithAPI(content: content)
                 self.setFeedbackGenerator()
-            })
+    
+                switch type {
+                case .message:
+                    return
+                case .first:
+                    Analytics.logEvent(Tracking.Select.clickSparkFighting, parameters: nil)
+                case .second:
+                    Analytics.logEvent(Tracking.Select.clickSparkTogether, parameters: nil)
+                case .third:
+                    Analytics.logEvent(Tracking.Select.clickSparkUonly, parameters: nil)
+                case .fourth:
+                    Analytics.logEvent(Tracking.Select.clickSparkHurry, parameters: nil)
+                }})
             .disposed(by: disposeBag)
     }
     
@@ -403,22 +417,9 @@ extension SendSparkVC {
 // MARK: - SendSparkCellDelegate
 
 extension SendSparkVC: SendSparkCellDelegate {
-    func sendSpark(with content: String, type: SendSparkStatus?) {
-        sendSparkButtonTapped.accept(content)
-        
-        guard let type = type else { return }
-        switch type {
-        case .message:
-            Analytics.logEvent(Tracking.Select.clickSparkInputText, parameters: nil)
-        case .first:
-            Analytics.logEvent(Tracking.Select.clickSparkFighting, parameters: nil)
-        case .second:
-            Analytics.logEvent(Tracking.Select.clickSparkTogether, parameters: nil)
-        case .third:
-            Analytics.logEvent(Tracking.Select.clickSparkUonly, parameters: nil)
-        case .fourth:
-            Analytics.logEvent(Tracking.Select.clickSparkHurry, parameters: nil)
-        }
+    func sendSpark(with content: String, type: SendSparkStatus) {
+        sendSparkButtonTapped.accept(["content": content,
+                                      "type": type])
     }
     func showTextField() {
         showAnimation()


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#587

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 메시지를 입력해서 보내는 `스파크보내기` 의 경우는 완전히 보내졌을 때 트래킹이 되야한다. 지금 현재는 각 스파크 보내기 버튼들을 선택하면 트래킹되고 있다.
- 이 부분을 메시지 입력 후 `보내기`, 키보드 `전송` 을 눌렀을 때 트래킹 하도록 변경했습니당
- SwiftLint 워닝도 트래킹 관련 풀리퀘이기 때문에 추가로 해결해두었습니다.\
> 문자열 열거형은 enum case 이름과 동일할 때 생략 가능하다.

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 해당 SwiftLint 워닝 참고 페이지
> [Redundant String Enum Value](https://realm.github.io/SwiftLint/redundant_string_enum_value.html)

## 📟 관련 이슈
- Resolved: #587
