### PR TITLE
[Bug] #547 - 탭바 이동 후에 습관방 복제 및 강제종료 해결

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -21,9 +21,10 @@ class HomeVC: UIViewController {
     private let emptyLabel = UILabel()
     private let emptyBackgroundView = UIImageView()
     
-    private var habitRoomList: [Room]? = []
-    private var habitRoomLastID: Int = -1
-    private var habitRoomCountSize: Int = 8
+    private var newHabitRooms: [Room] = []
+    private var habitRooms: [Room] = []
+    private var habitRoomInitID: Int = -1
+    private let habitRoomCountSize: Int = 8
     private var isInfiniteScroll: Bool = true
     private var isNewNotice: Bool = false
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -63,7 +63,6 @@ class HomeVC: UIViewController {
             self.newNoticeFetchWithAPI {
                 self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
                     self.habitRooms = self.newHabitRooms
-                    
                     if self.habitRooms.count != 0 {
                         self.mainCollectionView.reloadData()
                         self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
@@ -256,7 +255,6 @@ extension HomeVC {
             self.newNoticeFetchWithAPI {
                 self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
                     self.habitRooms = self.newHabitRooms
-                    self.refreshControl.endRefreshing()
                     self.mainCollectionView.reloadData()
                     
                     if self.isNewNotice {
@@ -264,6 +262,8 @@ extension HomeVC {
                     } else {
                         self.customNavigationBar.buttonsImage("icProfile", "icNotice")
                     }
+                    
+                    self.refreshControl.endRefreshing()
                 }
             }
         }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -57,16 +57,15 @@ class HomeVC: UIViewController {
         setNavigationBar()
         setTabBar()
         setFloatingButton()
-        
-        self.habitRoomLastID = -1
-        self.habitRoomList?.removeAll()
-        
-        self.setLoading()
+        setLoading()
         
         DispatchQueue.main.async {
             self.newNoticeFetchWithAPI {
-                self.habitRoomFetchWithAPI(lastID: self.habitRoomLastID) {
-                    if self.habitRoomList?.count != 0 {
+                self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
+                    self.habitRooms = self.newHabitRooms
+                    
+                    if self.habitRooms.count != 0 {
+                        self.mainCollectionView.reloadData()
                         self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
                         if self.isNewNotice {
                             self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
@@ -253,13 +252,12 @@ extension HomeVC {
     
     @objc
     private func refreshCollectionView() {
-        habitRoomLastID = -1
-        habitRoomList?.removeAll()
-        
         DispatchQueue.main.async {
             self.newNoticeFetchWithAPI {
-                self.habitRoomFetchWithAPI(lastID: self.habitRoomLastID) {
+                self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
+                    self.habitRooms = self.newHabitRooms
                     self.refreshControl.endRefreshing()
+                    self.mainCollectionView.reloadData()
                     
                     if self.isNewNotice {
                         self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
@@ -296,19 +294,17 @@ extension HomeVC {
     
     @objc
     private func updateHome() {
-        self.habitRoomLastID = -1
-        self.habitRoomList?.removeAll()
-        
-        DispatchQueue.main.async {
-            self.setNavigationBar()
-            self.setLoading()
-        }
+        setNavigationBar()
+        setLoading()
         
         DispatchQueue.main.async {
             self.newNoticeFetchWithAPI {
-                self.habitRoomFetchWithAPI(lastID: self.habitRoomLastID) {
-                    if self.habitRoomList?.count != 0 {
+                self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
+                    self.habitRooms = self.newHabitRooms
+                    if self.habitRooms.count != 0 {
+                        self.mainCollectionView.reloadData()
                         self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
+                        
                         if self.isNewNotice {
                             self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
                         } else {
@@ -338,8 +334,10 @@ extension HomeVC: UICollectionViewDelegate {
             if isInfiniteScroll {
                 isInfiniteScroll = false
                 
-                habitRoomLastID = habitRoomList?.last?.roomID ?? 0
+                let habitRoomLastID = habitRooms.last?.roomID ?? 0
                 habitRoomFetchWithAPI(lastID: habitRoomLastID) {
+                    self.habitRooms.append(contentsOf: self.newHabitRooms)
+                    self.mainCollectionView.reloadData()
                     self.isInfiniteScroll = true
                 }
             }
@@ -347,16 +345,15 @@ extension HomeVC: UICollectionViewDelegate {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let habitRoomList = habitRoomList else { return }
-        if habitRoomList.count != 0 {
-            if habitRoomList[indexPath.item].isStarted == true {
+        if habitRooms.count != 0 {
+            if habitRooms[indexPath.item].isStarted == true {
                 // 습관방
                
-                guard let roomStatus = RoomStatus(rawValue: habitRoomList[indexPath.item].myStatus ?? "NONE") else { return }
+                guard let roomStatus = RoomStatus(rawValue: habitRooms[indexPath.item].myStatus ?? "NONE") else { return }
                 switch roomStatus {
                 case .none, .rest, .done:
                     guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.habitRoom, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.habitRoom) as? HabitRoomVC else { return }
-                    nextVC.roomID = habitRoomList[indexPath.item].roomID
+                    nextVC.roomID = habitRooms[indexPath.item].roomID
                     
                     navigationController?.pushViewController(nextVC, animated: true)
                 case .complete:
@@ -365,7 +362,7 @@ extension HomeVC: UICollectionViewDelegate {
                     dialogueVC.roomStatus = .complete
                     dialogueVC.modalTransitionStyle = .crossDissolve
                     dialogueVC.modalPresentationStyle = .overFullScreen
-                    dialogueVC.roomID = habitRoomList[indexPath.item].roomID
+                    dialogueVC.roomID = habitRooms[indexPath.item].roomID
                     
                     present(dialogueVC, animated: true, completion: nil)
                 case .fail:
@@ -374,16 +371,16 @@ extension HomeVC: UICollectionViewDelegate {
                     dialogueVC.roomStatus = .fail
                     dialogueVC.modalTransitionStyle = .crossDissolve
                     dialogueVC.modalPresentationStyle = .overFullScreen
-                    dialogueVC.roomID = habitRoomList[indexPath.item].roomID
+                    dialogueVC.roomID = habitRooms[indexPath.item].roomID
                     
                     present(dialogueVC, animated: true, completion: nil)
                 }
             } else {
                 // 대기방
                 guard let waitingVC = UIStoryboard(name: Const.Storyboard.Name.waiting, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.waiting) as? WaitingVC else { return }
-                waitingVC.roomId = habitRoomList[indexPath.item].roomID
+                waitingVC.roomId = habitRooms[indexPath.item].roomID
                 waitingVC.fromWhereStatus = .fromHome
-                waitingVC.roomName = habitRoomList[indexPath.item].roomName
+                waitingVC.roomName = habitRooms[indexPath.item].roomName
                 
                 navigationController?.pushViewController(waitingVC, animated: true)
             }
@@ -395,31 +392,29 @@ extension HomeVC: UICollectionViewDelegate {
 
 extension HomeVC: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let count = habitRoomList?.count ?? 0
-        return count
+        return habitRooms.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let habitRoomList = habitRoomList else { return UICollectionViewCell()}
-        if habitRoomList.count != 0 {
+        if habitRooms.count != 0 {
             collectionView.isScrollEnabled = true
-            if habitRoomList[indexPath.item].isStarted == false {
+            if habitRooms[indexPath.item].isStarted == false {
                 guard let waitingCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.homeWaitingCVC, for: indexPath) as? HomeWaitingCVC else { return UICollectionViewCell() }
                 
-                waitingCVC.initCell(roomName: habitRoomList[indexPath.item].roomName)
+                waitingCVC.initCell(roomName: habitRooms[indexPath.item].roomName)
                 
                 return waitingCVC
             } else {
                 guard let habitCVC = collectionView.dequeueReusableCell(withReuseIdentifier: Const.Cell.Identifier.homeHabitCVC, for: indexPath) as? HomeHabitCVC else { return UICollectionViewCell() }
                 
-                habitCVC.initCell(roomName: habitRoomList[indexPath.item].roomName,
-                                  leftDay: habitRoomList[indexPath.item].leftDay ?? 0,
-                                  profileImg: habitRoomList[indexPath.item].profileImg,
-                                  life: habitRoomList[indexPath.item].life ?? 0,
-                                  status: habitRoomList[indexPath.item].myStatus ?? "NONE",
-                                  memberNum: habitRoomList[indexPath.item].memberNum ?? 0,
-                                  doneMemberNum: habitRoomList[indexPath.item].doneMemberNum ?? 0,
-                                  isUploaded: habitRoomList[indexPath.item].isUploaded)
+                habitCVC.initCell(roomName: habitRooms[indexPath.item].roomName,
+                                  leftDay: habitRooms[indexPath.item].leftDay ?? 0,
+                                  profileImg: habitRooms[indexPath.item].profileImg,
+                                  life: habitRooms[indexPath.item].life ?? 0,
+                                  status: habitRooms[indexPath.item].myStatus ?? "NONE",
+                                  memberNum: habitRooms[indexPath.item].memberNum ?? 0,
+                                  doneMemberNum: habitRooms[indexPath.item].doneMemberNum ?? 0,
+                                  isUploaded: habitRooms[indexPath.item].isUploaded)
                 return habitCVC
             }
         } else {
@@ -433,13 +428,11 @@ extension HomeVC: UICollectionViewDataSource {
 
 extension HomeVC: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        guard let habitRoomList = habitRoomList else { return .zero }
-        
         let cellWidth = collectionView.frame.width - 40
         let collectionViewHeight = collectionView.frame.height
         
-        if habitRoomList.count != 0 {
-            if habitRoomList[indexPath.item].isStarted == false {
+        if habitRooms.count != 0 {
+            if habitRooms[indexPath.item].isStarted == false {
                 let waitingCellHeight = cellWidth * (98/335)
                 return CGSize(width: cellWidth, height: waitingCellHeight)
             } else {
@@ -474,13 +467,13 @@ extension HomeVC {
                 self.loadingView.stop()
                 self.loadingView.removeFromSuperview()
                 self.loadingBgView.removeFromSuperview()
-                if let habitRooms = data as? HabitRoom {
-                    self.habitRoomList?.append(contentsOf: habitRooms.rooms)
-                    if self.habitRoomList?.count == 0 {
+                
+                if let habitRoom = data as? HabitRoom {
+                    self.newHabitRooms = habitRoom.rooms
+                    if self.newHabitRooms.count == 0, self.habitRooms.count == 0 {
                         self.setEmptyView()
                     } else {
                         self.updateHiddenCollectionView()
-                        self.mainCollectionView.reloadData()
                     }
                 }
                 


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#547 

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- list 라는 네이밍보다 복수를 사용하도록 권유되어서 habitRooms 로 네이밍 변경
- list 라는 네이밍보다 복수를 사용하도록 권유되어서 feeds 로 네이밍 변경
> 예를들어 nameTextString 이 아닌 nameText 로 변수명에서 직접적으로 해당 타입을 의미하는 네이밍 컨밴션은 권유되지 않는다고 해요!
> 그래서 배열에 list 를 붙이는것이 아닌 복수로써 사용하더라구요.
- 탭바를 빠르게 전환시 이전 서버통신이 종료되고 append 를 통해서 새로운 서버통신의 결과와 중복으로 추가되기때문에 UI 와 출동해서 비정상종료가 발생했는데 viewWillAppear 에서 append 가 아닌 대체해서 해결
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 서버 통신을 취소해주는 작업도 생각을 해봤는데 moya 에서 아예 지원을 하지 않는 것은 아니고 아래 이슈를 보면 `.cancel()` 메서드를 통해서 가능은 한데(moya 에서 서버통신을 요청하는 request 를 취소하는 방법) 저희는 Service 라는 파일에서 provider 를 통해서 request 를 만들다보니까 이걸 호출하는 뷰컨에서 저장하거나 또 탭바가 전환됨을 추적하기에 쉽지 않다고 판단했어요!
> https://github.com/Moya/Moya/issues/1023

- 그래서 애초에 문제였던 append 하는 방법에 대해서 의문을 가졌고, 초기에는 last id 도, 저장했던 배열들도 다 덮어씌어줘도 된다고 생각했어요! 그래서 서버통신이 끝난 후 newFeeds, newHabitRooms 지역 변수에 저장을 하고 completion handler 에서 이부분을 처음에는 덮어씌우고 무한스크롤때는 append 하는 과정으로 변경하면서 로직을 변경하였습니당.
- 다만 피드의 경우는 지금 서버로 부터 데이터를 받고 일곱개의 배열에 넣는 등의 가공하는 과정(`setData()` 라는 메서드)이 있기때문에 홈처럼 하기보다 removeAll 을 해주고 setData 를 진행했습니당!

### 🚨제 로직이 아니다보니 피드의 경우는 수빈이가 신경써서 한번 봐주시면 고마울거 같아요! 제가 테스트해본 결과는 정상적으로 작동하는데 간단한 QA 라도 지혜쌤한테 부탁드려야할거 같아요!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|탭바전환|<img src = "https://user-images.githubusercontent.com/69136340/166390992-7734cbdd-94dc-4555-9562-329139bcbd88.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #547
- Resolved: #543
