### PR TITLE
[Fix] #593 - 알림 뷰 스크롤할 때 버튼 전환시 터지는 문제 해결

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Notice/NoticeVC.swift
@@ -62,6 +62,7 @@ class NoticeVC: UIViewController {
                 self.serviceBadgeView.isHidden = true
             }
             self.activeReadWithAPI()
+            self.collectionView.reloadData()
         }
     }
     
@@ -147,11 +148,6 @@ class NoticeVC: UIViewController {
         collectionView.dataSource = self
     }
     
-//    private func setAddTarget() {
-//        activeButton.addTarget(self, action: #selector(touchActiveButton), for: .touchUpInside)
-//        serviceButton.addTarget(self, action: #selector(touchServiceButton), for: .touchUpInside)
-//    }
-    
     private func bindButton() {
         activeButton.rx.tap
             .throttle(.seconds(3), latest: false, scheduler: MainScheduler.instance)
@@ -205,7 +201,6 @@ class NoticeVC: UIViewController {
         activeBadgeView.isHidden = true
         makeDrawAboveButton(button: activeButton)
         
-        isActivity = true
         activeLastID = -1
         activeList.removeAll()
         
@@ -223,6 +218,8 @@ class NoticeVC: UIViewController {
 
         group.notify(queue: .main) {
             self.activeReadWithAPI()
+            self.isActivity = true
+            self.collectionView.reloadData()
             if !self.collectionView.isHidden {
                 self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
             }
@@ -236,7 +233,6 @@ class NoticeVC: UIViewController {
         serviceBadgeView.isHidden = true
         makeDrawAboveButton(button: serviceButton)
         
-        isActivity = false
         serviceLastID = -1
         serviceList.removeAll()
         
@@ -254,6 +250,8 @@ class NoticeVC: UIViewController {
 
         group.notify(queue: .main) {
             self.serviceReadWithAPI()
+            self.isActivity = false
+            self.collectionView.reloadData()
             if !self.collectionView.isHidden {
                 self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
             }
@@ -362,14 +360,12 @@ extension NoticeVC {
             switch response {
             case .success(let data):
                 if let active = data as? ActiveNotice {
-                    self.serviceList.removeAll()
                     self.newService = active.newService
                     self.activeList.append(contentsOf: active.notices)
                     if self.activeList.isEmpty {
                         self.setEmptyView()
                     } else {
                         self.updateHiddenCollectionView()
-                        self.collectionView.reloadData()
                     }
                 }
                 completion()
@@ -390,14 +386,12 @@ extension NoticeVC {
             switch response {
             case .success(let data):
                 if let service = data as? ServiceNotice {
-                    self.activeList.removeAll()
                     self.newActive = service.newActive
                     self.serviceList.append(contentsOf: service.notices)
                     if self.serviceList.isEmpty {
                         self.setEmptyView()
                     } else {
                         self.updateHiddenCollectionView()
-                        self.collectionView.reloadData()
                     }
                 }
                 completion()


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#593

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
알림 뷰 스크롤할 때 버튼 전환시 터지는 문제 해결

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
`isActivity`에 따라 `numberOfItemsInSection` , `cellForItemAt` 등 `reloadData`할때 필요한 부분들을 분기처리했는데, 
`isActivity` 시점이 서버 통신 전에 있었어서 서버 통신 이후 `reloadData` 전으로 옮겨줬습니다

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## 📟 관련 이슈
- Resolved: #593 
