### PR TITLE
[Refactor] #571 - SendSparkButton 이니셜라이저를 활용한 초기화로 리펙토링

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
+++ b/Spark-iOS/Spark-iOS/Source/Classes/SendSparkButton.swift
@@ -20,23 +20,23 @@ final class SendSparkButton: UIButton {
     
     // MARK: - Properties
     
-    var type: SendSparkStatus?
+    var type: SendSparkStatus {
+        didSet {
+            self.setContent()
+        }
+    }
     var content: String?
     
     // MARK: - Initialize
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public init(type: SendSparkStatus) {
+    init(type: SendSparkStatus) {
+        self.type = type
         super.init(frame: .zero)
-        
-        setUI(type)
+        setUI(self.type)
     }
 }
 
@@ -53,8 +53,10 @@ extension SendSparkButton {
         self.titleLabel?.lineBreakMode = .byCharWrapping
         self.titleLabel?.textAlignment = .center
         self.type = type
-        
-        switch type {
+    }
+    
+    private func setContent() {
+        switch self.type {
         case .message:
             self.setTitle("""
                           메시지
@@ -95,20 +97,6 @@ extension SendSparkButton {
                           """,
                           for: .normal)
             self.content = "👍얼마 안 남았어, 어서 하자!"
-        }
-    }
-    
-    public func isSelected(_ isSelected: Bool) {
-        if isSelected {
-            self.setTitleColor(.sparkDarkPinkred, for: .normal)
-            self.backgroundColor = .sparkMostLightPinkred
-            self.titleLabel?.backgroundColor = .sparkMostLightPinkred
-            self.layer.borderColor = UIColor.sparkDarkPinkred.cgColor
-        } else {
-            self.setTitleColor(.sparkLightPinkred, for: .normal)
-            self.backgroundColor = .sparkWhite
-            self.titleLabel?.backgroundColor = .sparkWhite
-            self.layer.borderColor = UIColor.sparkLightPinkred.cgColor
         }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#571

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 불필요한 오버라이드하던 생성자 삭제.
- UI 가 변경되면서 사용하지 않던 `isSelected` 삭제.
- `didset` property observer 를 통해서 content 설정

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 자식클래스에서 초기화를 하는 과정은 다음과 같이 진행해야해요!
1.자식 클래스의 프로퍼티 초기화
2.부모 클래스의 초기화 메서드 호출
3.자식 클래스의 나머지 초기화 동작 (메서드 등)

덮어씌워지지 않기 위해서입니당.
그래서 위와 같이 이니셜라이저를 수정했습니당.(2단계 초기화로 검색하면 좀 더 자세하게 얻을 수 있을거에용)

편의 이니셜라이저가 지정이니셜라이저를 호출하고 지정이니셜라이저는 부모의 지정이니셜라이저를 호출하게되요! 그리고  subclass 아래로 내려오면서 프로퍼티에 접근할 수 있게되요! 그렇다면 코드에서처럼 `super.init()` 이전의 값 설정은요? -> 저장프로퍼티에 대해서 초기화를 하지 않은채로 지정이니셜라이저를 호출할 수 없기때문에! 순서가 지켜져야해요! 그후에 self 에 접근이 가능하다고 하네요!
![스크린샷 2022-05-09 오후 11 32 00](https://user-images.githubusercontent.com/69136340/167432824-7190a6d9-c0d7-4fae-bf85-a99c78dc59f4.png)

> 초기화 (Initialization) 참고로 공부하면서 했어요! 
> https://jusung.gitbook.io/the-swift-language-guide/language-guide/14-initialization
## 📟 관련 이슈
- Resolved: #571
