### PR TITLE
[Feat] #603 - 인증한 유저에게 스파크 보내기했을 때 예외처리

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Room/RoomAPI.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Room/RoomAPI.swift
@@ -216,12 +216,28 @@ public class RoomAPI {
             case .success(let response):
                 let statusCode = response.statusCode
                 let data = response.data
-                let networkResult = self.judgeStatus(by: statusCode, data)
+                let networkResult = self.judgeSendSparkStatus(by: statusCode, data)
                 completion(networkResult)
                 
             case .failure(let err):
                 print(err)
             }
+        }
+    }
+    
+    private func judgeSendSparkStatus(by statusCode: Int, _ data: Data) -> NetworkResult<Any> {
+        let decoder = JSONDecoder()
+        guard let decodedData = try? decoder.decode(GenericResponse<String>.self, from: data)
+        else { return .pathErr }
+        switch statusCode {
+        case 200:
+            return .success(decodedData.message)
+        case 400..<500:
+            return .requestErr(decodedData.status)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
         }
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -211,6 +211,7 @@ extension SendSparkVC {
     // MARK: - @objc Function
     @objc
     private func sendSparkWithMessage() {
+        setFeedbackGenerator()
         sendSparkWithAPI(content: textField.text ?? "")
         Analytics.logEvent(Tracking.Select.clickSparkInputText, parameters: nil)
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -475,13 +475,7 @@ extension SendSparkVC: UICollectionViewDataSource {
 
 // MARK: - UICollectionViewDelegate
 
-extension SendSparkVC: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
-        impactFeedbackGenerator?.impactOccurred()
-        impactFeedbackGenerator = nil
-    }
-}
+extension SendSparkVC: UICollectionViewDelegate { }
 
 // MARK: Network
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/SendSparkVC.swift
@@ -488,8 +488,18 @@ extension SendSparkVC {
                 self.dismiss(animated: true) {
                     presentVC?.showSparkToast(x: 20, y: 44, message: "\(self.userName ?? "")에게 스파크를 보냈어요!")
                 }
-            case .requestErr(let message):
-                print("sendSparkWithAPI - requestErr: \(message)")
+            case .requestErr(let status):
+                if status as? Int == 440 {
+                    let presentVC = self.presentingViewController
+                    self.dismiss(animated: true) {
+                        NotificationCenter.default.post(name: .updateHabitRoom, object: nil)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            presentVC?.showSparkToast(x: 20, y: 44, message: "\(self.userName ?? "")에게 스파크를 보냈어요!")
+                        }
+                    }
+                }
+
+                print("sendSparkWithAPI - requestErr: \(status)")
             case .pathErr:
                 print("sendSparkWithAPI - pathErr")
             case .serverErr:


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#603

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- `bind` 메서드에서 impact feedback generator 가 작동하고 있어서, collection view delegate 에서 실행하던 함수는 중복되기에 삭제해주었다.
- 이미 인증한 사용자에게 스파크 보내기를 할 경우 440 상태코드를 받기로 했고, 이때 습관방으로 돌아가서 로딩창과 함께 토스트메시지를 보여주기로 한 사항을 반영했습니다.
- 스파크를 보내고 토스트메시지를 등장시키는 경험이 햅틱으로 이루어져서 `메시지 직접 입력하기` 를 누르고 `보내기` 버튼에 햅틱을 부여했습니다.
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 현재 개발중인 내용들은 다음 업데이트에 1차적으로 반영할 예정이고, 잠시 쉬고오자구요!!
## 📟 관련 이슈
- Resolved: #603
