### PR TITLE
[Bug] #618 - 습관방 한 개일 때 삭제(실패, 방 삭제, 나가기) 후, 새로고침 후 사라지지 않는 버그

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -63,14 +63,19 @@ class HomeVC: UIViewController {
             self.newNoticeFetchWithAPI {
                 self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
                     self.habitRooms = self.newHabitRooms
+                    self.mainCollectionView.reloadData()
+                    
                     if self.habitRooms.count != 0 {
-                        self.mainCollectionView.reloadData()
+                        self.updateHiddenCollectionView()
                         self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
-                        if self.isNewNotice {
-                            self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
-                        } else {
-                            self.customNavigationBar.buttonsImage("icProfile", "icNotice")
-                        }
+                    } else {
+                        self.setEmptyView()
+                    }
+                    
+                    if self.isNewNotice {
+                        self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
+                    } else {
+                        self.customNavigationBar.buttonsImage("icProfile", "icNotice")
                     }
                 }
             }
@@ -257,6 +262,12 @@ extension HomeVC {
                     self.habitRooms = self.newHabitRooms
                     self.mainCollectionView.reloadData()
                     
+                    if self.habitRooms.count != 0 {
+                        self.updateHiddenCollectionView()
+                    } else {
+                        self.setEmptyView()
+                    }
+                    
                     if self.isNewNotice {
                         self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
                     } else {
@@ -301,15 +312,19 @@ extension HomeVC {
             self.newNoticeFetchWithAPI {
                 self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
                     self.habitRooms = self.newHabitRooms
+                    self.mainCollectionView.reloadData()
+                    
                     if self.habitRooms.count != 0 {
-                        self.mainCollectionView.reloadData()
+                        self.updateHiddenCollectionView()
                         self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
-                        
-                        if self.isNewNotice {
-                            self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
-                        } else {
-                            self.customNavigationBar.buttonsImage("icProfile", "icNotice")
-                        }
+                    } else {
+                        self.setEmptyView()
+                    }
+                    
+                    if self.isNewNotice {
+                        self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
+                    } else {
+                        self.customNavigationBar.buttonsImage("icProfile", "icNotice")
                     }
                 }
             }
@@ -470,11 +485,6 @@ extension HomeVC {
                 
                 if let habitRoom = data as? HabitRoom {
                     self.newHabitRooms = habitRoom.rooms
-                    if self.newHabitRooms.count == 0, self.habitRooms.count == 0 {
-                        self.setEmptyView()
-                    } else {
-                        self.updateHiddenCollectionView()
-                    }
                 }
                 
                 completion()


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#618

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 기존에 habitRooms 의 count 가 1이 아닐경우만 대응해주고 0일 경우를 대응하지 않았다. 왜냐면, 서버통신 코드에서 현재 현재 습관방 목록과 새로 가져온 습관방의 목록이 비었을때만 엠티뷰를 세팅해줬다. 그런데  ***습관방 목록이 한 개일 때 삭제(실패 확인, 방 삭제, 나가기) 하고 홈으로 와서 새로고침을 하게 되면 현재 습관방 목록은 한 개고(로컬데이터) 새로 가져온 습관방 목록은 비어있기 때문에 엠티뷰가 아닌 한개의 목록이 등장했다.***
- 위의 점으로 버그를 파악했고, 서버통신에서 UI 를 통제하던 메서드를 분리해서 순전히 `habitRooms` 만 갱신하는 역할인 `newHabitRooms` 에 저장해주었습니다.
- 습관방 목록을 가져오는 서버통신이 사용되는 모든 곳의 completion 에 분기처리를 다시금 해주었습니당
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|실패 후 새로고침|<img src = "https://user-images.githubusercontent.com/69136340/168652137-92095386-adea-4783-9710-de5cfeb8b646.mp4" width ="250">|

~**대기방 나가기, 방 나가기 모두 확인했고, 내일 밤...12시... 실패방 확인하기 후 스크린샷 올리고 태그할게용**~

### *@yangsubinn @L-j-h-c 정상 작동 확인 했습니당!*

## 📟 관련 이슈
- Resolved: #618
