### PR TITLE
[Feat] #608 - 스플래시 뷰에서 OS 정보 서버로 보내기

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthService.swift
@@ -65,7 +65,8 @@ extension AuthService: TargetType {
             return .uploadMultipart(multiPartData)
         case .login(let socialID, let fcmToken):
             return .requestParameters(parameters: ["socialId": socialID,
-                                                   "fcmToken": fcmToken],
+                                                   "fcmToken": fcmToken,
+                                                   "os": "ios"],
                                       encoding: URLEncoding.queryString)
         case .signout:
             return .requestPlain


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#608

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- doorbellAPI 에서 os 키값을 가지고 `ios` 넘겨주었습니다.
- 서버에서 해당 사용자의 OS 정보를 가지고 있으면 앞으로 다양한 활동에 유리하다고 판단하고 api 를 변경하셨다고 합니당.
> 시스템적인 공지 및 홍보 등 OS 구별되게 푸시알림으로써 보낼 수 있다는 점이 장점이라고 하셨습니당

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|postman - doorbell API|<img width="1000" alt="스크린샷 2022-05-16 오후 5 16 16" src="https://user-images.githubusercontent.com/69136340/168549196-698d66ec-6e67-4af6-9d62-b98309e954a6.png">|

## 📟 관련 이슈
- Resolved: #608
