### PR TITLE
[Fix] #609 - 스플래시 중에 앱스토어 버전 확인을 위해서 잠시 멈춤 해결

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Splash/SplashVC.swift
@@ -49,10 +49,9 @@ class SplashVC: UIViewController {
 
         setUI()
         setLayout()
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1) {
-            if self.checkUpdateAvailable() {
-                self.presentToForceUpdateDialougeVC()
-            }
+        
+        if self.checkUpdateAvailable() {
+            self.presentToForceUpdateDialougeVC()
         }
     }
     


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#609

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- Data(contentsOf:) 서버통신이 동기적이니까 기존의 main 큐에서 수행시키는 것은 해당 이슈처럼 UI 가 멈추는 것이 맞았습니당
- DispatchQueue.global() 을 사용하지 않으니까 기다리다가 스플래시 로티가 실행되더라구요 그래서 의도하는 시나리오는 로티 실행 후에 동기적인 서버통신이 이루어지기 위함이었습니다. 그런데 로티의 종료 타이밍을 잡기 애매했고,
- 그래서, concurrent queue 를 사용해서 병렬적으로 실행해주고, 비동기적으로 처리했습니다.
> 서버통신 과정을 global 큐에 넣었기때문에 기다림없이 실행되었습니다.
- DispatchQueue.global()  에서 통신하고, UI 관련한 부분은 main 큐에서 수행하도록 했습니다.
> main 에서 수행하지 않으면 main 쓰레드에서 수행해야한다면서 앱이 종료됩니다. 

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 3G 에서 실행한 것을 첨부합니당

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|3G 설정|<img src = "https://user-images.githubusercontent.com/69136340/168575629-2a2ca898-50ed-412a-b64b-c7a3b350d5f3.PNG" width ="150">|
|스플래시|<img src = "https://user-images.githubusercontent.com/69136340/168590233-57966d33-e717-4cae-a3f9-5fc7616b9ca5.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #609
