### PR TITLE
Feature/#626

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -255,14 +255,9 @@ extension AuthUploadVC {
     // 업로드
     @objc
     func touchUploadButton() {
-        DispatchQueue.main.async {
-            self.setLoading()
-        }
-        
-        DispatchQueue.main.async {
-            self.authUploadWithAPI()
-            self.uploadTracking()
-        }
+        setLoading()
+        authUploadWithAPI()
+        uploadTracking()
     }
     
     // MARK: - Screen Change

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/HabitRoom/HabitRoomVC.swift
@@ -436,24 +436,17 @@ extension HabitRoomVC {
     
     @objc
     private func updateHabitRoom() {
-        DispatchQueue.main.async {
-            // 로딩
-            self.setLoading()
-        }
-        DispatchQueue.main.async {
-            self.fetchHabitRoomDetailWithAPI(roomID: self.roomID ?? 0) {
-                self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
-                self.setHabitRoomGuide()
-            }
+        setLoading()
+        fetchHabitRoomDetailWithAPI(roomID: self.roomID ?? 0) {
+            self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
+            self.setHabitRoomGuide()
         }
     }
     
     @objc
     private func updateWithRefreshControl() {
-        DispatchQueue.main.async {
-            self.fetchHabitRoomDetailWithAPI(roomID: self.roomID ?? 0) {
-                self.refreshControl.endRefreshing()
-            }
+        fetchHabitRoomDetailWithAPI(roomID: self.roomID ?? 0) {
+            self.refreshControl.endRefreshing()
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/StorageMore/StorageMoreVC.swift
@@ -55,12 +55,12 @@ class StorageMoreVC: UIViewController {
         setLayout()
         
         DispatchQueue.main.async { [self] in
-            if self.isChangingImageView {
-                self.getMyRoomCertiChangeWithAPI(lastID: myRoomCertificationLastID, size: myRoomCountSize) { [self] in
+            if isChangingImageView {
+                getMyRoomCertiChangeWithAPI(lastID: myRoomCertificationLastID, size: myRoomCountSize) { [self] in
                     storageMoreCV.reloadData()
                 }
             } else {
-                self.getMyRoomCertiWithAPI(lastID: myRoomCertificationLastID, size: myRoomCountSize) { [self] in
+                getMyRoomCertiWithAPI(lastID: myRoomCertificationLastID, size: myRoomCountSize) { [self] in
                     storageMoreCV.reloadData()
                 }
             }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/FeedVC.swift
@@ -54,7 +54,7 @@ class FeedVC: UIViewController {
         setNotification()
         initRefreshControl()
     }
-
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -62,32 +62,30 @@ class FeedVC: UIViewController {
         setFloatingButton()
         
         navigationController?.isNavigationBarHidden = true
-
+        
         setLoading()
         
-        DispatchQueue.main.async {
-            self.getFeedListFetchWithAPI(lastID: self.feedInitID) {
-                self.feeds = self.newFeeds
-                if self.feeds.count >= self.feedCountSize {
-                    self.isFirstScroll = false
-                }
-                
-                self.dateList.removeAll()
-                self.dayList.removeAll()
-                
-                self.firstList.removeAll()
-                self.secondList.removeAll()
-                self.thirdList.removeAll()
-                self.fourthList.removeAll()
-                self.fifthList.removeAll()
-                self.sixthList.removeAll()
-                self.seventhList.removeAll()
-                
-                self.setData(datalist: self.newFeeds)
-                if !self.feeds.isEmpty {
-                    self.collectionView.reloadData()
-                    self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
-                }
+        getFeedListFetchWithAPI(lastID: self.feedInitID) {
+            self.feeds = self.newFeeds
+            if self.feeds.count >= self.feedCountSize {
+                self.isFirstScroll = false
+            }
+            
+            self.dateList.removeAll()
+            self.dayList.removeAll()
+            
+            self.firstList.removeAll()
+            self.secondList.removeAll()
+            self.thirdList.removeAll()
+            self.fourthList.removeAll()
+            self.fifthList.removeAll()
+            self.sixthList.removeAll()
+            self.seventhList.removeAll()
+            
+            self.setData(datalist: self.newFeeds)
+            if !self.feeds.isEmpty {
+                self.collectionView.reloadData()
+                self.collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
             }
         }
     }
@@ -237,30 +235,28 @@ class FeedVC: UIViewController {
     
     @objc
     private func refreshCollectionView() {
-        DispatchQueue.main.async {
-            self.getFeedListFetchWithAPI(lastID: self.feedInitID) {
-                self.feeds = self.newFeeds
-                if self.feeds.count >= self.feedCountSize {
-                    self.isFirstScroll = false
-                }
-                
-                self.dateList.removeAll()
-                self.dayList.removeAll()
-                
-                self.firstList.removeAll()
-                self.secondList.removeAll()
-                self.thirdList.removeAll()
-                self.fourthList.removeAll()
-                self.fifthList.removeAll()
-                self.sixthList.removeAll()
-                self.seventhList.removeAll()
-                
-                self.setData(datalist: self.newFeeds)
-                if !self.feeds.isEmpty {
-                    self.collectionView.reloadData()
-                }
-                self.refreshControl.endRefreshing()
+        getFeedListFetchWithAPI(lastID: self.feedInitID) {
+            self.feeds = self.newFeeds
+            if self.feeds.count >= self.feedCountSize {
+                self.isFirstScroll = false
             }
+            
+            self.dateList.removeAll()
+            self.dayList.removeAll()
+            
+            self.firstList.removeAll()
+            self.secondList.removeAll()
+            self.thirdList.removeAll()
+            self.fourthList.removeAll()
+            self.fifthList.removeAll()
+            self.sixthList.removeAll()
+            self.seventhList.removeAll()
+            
+            self.setData(datalist: self.newFeeds)
+            if !self.feeds.isEmpty {
+                self.collectionView.reloadData()
+            }
+            self.refreshControl.endRefreshing()
         }
     }
     

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -63,14 +63,19 @@ class HomeVC: UIViewController {
             self.newNoticeFetchWithAPI {
                 self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
                     self.habitRooms = self.newHabitRooms
+                    self.mainCollectionView.reloadData()
+                    
                     if self.habitRooms.count != 0 {
-                        self.mainCollectionView.reloadData()
+                        self.updateHiddenCollectionView()
                         self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
-                        if self.isNewNotice {
-                            self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
-                        } else {
-                            self.customNavigationBar.buttonsImage("icProfile", "icNotice")
-                        }
+                    } else {
+                        self.setEmptyView()
+                    }
+                    
+                    if self.isNewNotice {
+                        self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
+                    } else {
+                        self.customNavigationBar.buttonsImage("icProfile", "icNotice")
                     }
                 }
             }
@@ -257,6 +262,12 @@ extension HomeVC {
                     self.habitRooms = self.newHabitRooms
                     self.mainCollectionView.reloadData()
                     
+                    if self.habitRooms.count != 0 {
+                        self.updateHiddenCollectionView()
+                    } else {
+                        self.setEmptyView()
+                    }
+                    
                     if self.isNewNotice {
                         self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
                     } else {
@@ -301,15 +312,19 @@ extension HomeVC {
             self.newNoticeFetchWithAPI {
                 self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
                     self.habitRooms = self.newHabitRooms
+                    self.mainCollectionView.reloadData()
+                    
                     if self.habitRooms.count != 0 {
-                        self.mainCollectionView.reloadData()
+                        self.updateHiddenCollectionView()
                         self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
-                        
-                        if self.isNewNotice {
-                            self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
-                        } else {
-                            self.customNavigationBar.buttonsImage("icProfile", "icNotice")
-                        }
+                    } else {
+                        self.setEmptyView()
+                    }
+                    
+                    if self.isNewNotice {
+                        self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
+                    } else {
+                        self.customNavigationBar.buttonsImage("icProfile", "icNotice")
                     }
                 }
             }
@@ -470,11 +485,6 @@ extension HomeVC {
                 
                 if let habitRoom = data as? HabitRoom {
                     self.newHabitRooms = habitRoom.rooms
-                    if self.newHabitRooms.count == 0, self.habitRooms.count == 0 {
-                        self.setEmptyView()
-                    } else {
-                        self.updateHiddenCollectionView()
-                    }
                 }
                 
                 completion()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -59,24 +59,22 @@ class HomeVC: UIViewController {
         setFloatingButton()
         setLoading()
         
-        DispatchQueue.main.async {
-            self.newNoticeFetchWithAPI {
-                self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
-                    self.habitRooms = self.newHabitRooms
-                    self.mainCollectionView.reloadData()
-                    
-                    if self.habitRooms.count != 0 {
-                        self.updateHiddenCollectionView()
-                        self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
-                    } else {
-                        self.setEmptyView()
-                    }
-                    
-                    if self.isNewNotice {
-                        self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
-                    } else {
-                        self.customNavigationBar.buttonsImage("icProfile", "icNotice")
-                    }
+        self.newNoticeFetchWithAPI {
+            self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
+                self.habitRooms = self.newHabitRooms
+                self.mainCollectionView.reloadData()
+                
+                if self.habitRooms.count != 0 {
+                    self.updateHiddenCollectionView()
+                    self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .bottom, animated: false)
+                } else {
+                    self.setEmptyView()
+                }
+                
+                if self.isNewNotice {
+                    self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
+                } else {
+                    self.customNavigationBar.buttonsImage("icProfile", "icNotice")
                 }
             }
         }
@@ -245,7 +243,7 @@ extension HomeVC {
         
         navigationController?.pushViewController(nextVC, animated: true)
     }
-
+    
     private func pushToNoticeVC() {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.notice, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.notice) as? NoticeVC else { return }
         
@@ -256,26 +254,24 @@ extension HomeVC {
     
     @objc
     private func refreshCollectionView() {
-        DispatchQueue.main.async {
-            self.newNoticeFetchWithAPI {
-                self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
-                    self.habitRooms = self.newHabitRooms
-                    self.mainCollectionView.reloadData()
-                    
-                    if self.habitRooms.count != 0 {
-                        self.updateHiddenCollectionView()
-                    } else {
-                        self.setEmptyView()
-                    }
-                    
-                    if self.isNewNotice {
-                        self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
-                    } else {
-                        self.customNavigationBar.buttonsImage("icProfile", "icNotice")
-                    }
-                    
-                    self.refreshControl.endRefreshing()
+        newNoticeFetchWithAPI {
+            self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
+                self.habitRooms = self.newHabitRooms
+                self.mainCollectionView.reloadData()
+                
+                if self.habitRooms.count != 0 {
+                    self.updateHiddenCollectionView()
+                } else {
+                    self.setEmptyView()
                 }
+                
+                if self.isNewNotice {
+                    self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
+                } else {
+                    self.customNavigationBar.buttonsImage("icProfile", "icNotice")
+                }
+                
+                self.refreshControl.endRefreshing()
             }
         }
     }
@@ -288,7 +284,7 @@ extension HomeVC {
             guard let isHost: Bool = notification.userInfo?["isHost"] as? Bool else { return }
             
             let message: String
-        
+            
             if roomName.count > 8 {
                 let index = roomName.index(roomName.startIndex, offsetBy: 8)
                 roomName = roomName[..<index] + "..."
@@ -307,25 +303,22 @@ extension HomeVC {
     private func updateHome() {
         setNavigationBar()
         setLoading()
-        
-        DispatchQueue.main.async {
-            self.newNoticeFetchWithAPI {
-                self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
-                    self.habitRooms = self.newHabitRooms
-                    self.mainCollectionView.reloadData()
-                    
-                    if self.habitRooms.count != 0 {
-                        self.updateHiddenCollectionView()
-                        self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
-                    } else {
-                        self.setEmptyView()
-                    }
-                    
-                    if self.isNewNotice {
-                        self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
-                    } else {
-                        self.customNavigationBar.buttonsImage("icProfile", "icNotice")
-                    }
+        newNoticeFetchWithAPI {
+            self.habitRoomFetchWithAPI(lastID: self.habitRoomInitID) {
+                self.habitRooms = self.newHabitRooms
+                self.mainCollectionView.reloadData()
+                
+                if self.habitRooms.count != 0 {
+                    self.updateHiddenCollectionView()
+                    self.mainCollectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: false)
+                } else {
+                    self.setEmptyView()
+                }
+                
+                if self.isNewNotice {
+                    self.customNavigationBar.buttonsImage("icProfile", "icNoticeNew")
+                } else {
+                    self.customNavigationBar.buttonsImage("icProfile", "icNotice")
                 }
             }
         }
@@ -363,7 +356,7 @@ extension HomeVC: UICollectionViewDelegate {
         if habitRooms.count != 0 {
             if habitRooms[indexPath.item].isStarted == true {
                 // 습관방
-               
+                
                 guard let roomStatus = RoomStatus(rawValue: habitRooms[indexPath.item].myStatus ?? "NONE") else { return }
                 switch roomStatus {
                 case .none, .rest, .done:

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/StorageVC.swift
@@ -97,7 +97,7 @@ class StorageVC: UIViewController {
         failRoomList?.removeAll()
         
         DispatchQueue.main.async { [self] in
-            self.setLoading()
+            setLoading()
         }
         
         let group = DispatchGroup.init()

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -95,14 +95,9 @@ class WaitingVC: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        DispatchQueue.main.async {
-            self.setLoading()
-        }
-        
-        DispatchQueue.main.async {
-            self.getWaitingRoomWithAPI(roomID: self.roomId ?? 0)
-        }
+    
+        setLoading()
+        getWaitingRoomWithAPI(roomID: self.roomId ?? 0)
         setTabBar()
         setFloatingButton()
     }


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#626

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 탈출 클로저의 획득목록에 self 를 명시하면 클로저 내부에서 암시적 self 사용이 가능해요!(Swift 5.3부! 얌얌!) ***준호의 경우에는 이 기능을 사용했는데 일부 코드에서 self 를 명시해줬지만 클로저 내부에서 여전히 self 를 사용하고 있어서 이부분은 제가 수정했습니다.*** 
- 기존에 서버코드와 UI 관련 코드가 구별되지 않았기에 스파게티 코드를 대응하기 위해서 DispatchQueue.main 를 사용해주었는데 지금은 많이 분리했을뿐더러 공부를 하면서 OS 가 알아서 처리해줄 것이라는 것을 알았고, 비동기 통신인 URLSession 을 기반으로 한 moya 를 사용하기 떄문에 별도로 큐를 통해서 비동기처리 해줄 이유도 없기때문에 무분별한 사용을 정리해서 가독성을 향상하고자 했습니다!

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 해당 작업은 #618 브랜치에 이어서 개발했습니다.


## 📟 관련 이슈
- Resolved: #626
