### PR TITLE
[Fix] CompressionQuality 0.5로 수정

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Auth/AuthService.swift
@@ -58,7 +58,7 @@ extension AuthService: TargetType {
             let fcmTokenData = fcmToken.data(using: .utf8) ?? Data()
             multiPartData.append(MultipartFormData(provider: .data(fcmTokenData), name: "fcmToken"))
             if let profileImg = profileImg {
-                let profileImgData = MultipartFormData(provider: .data(profileImg.jpegData(compressionQuality: 1.0) ?? Data()), name: "image", fileName: "image.jpeg", mimeType: "image/jpeg")
+                let profileImgData = MultipartFormData(provider: .data(profileImg.jpegData(compressionQuality: 0.5) ?? Data()), name: "image", fileName: "image.jpeg", mimeType: "image/jpeg")
                 multiPartData.append(profileImgData)
             }
             

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/Room/RoomService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/Room/RoomService.swift
@@ -113,7 +113,7 @@ extension RoomService: TargetType {
             let timerData = timer.data(using: .utf8) ?? Data()
             multiPartData.append(MultipartFormData(provider: .data(timerData), name: "timerRecord"))
             
-            let imageData = MultipartFormData(provider: .data(image.jpegData(compressionQuality: 1.0) ?? Data()), name: "image", fileName: "image.jpeg", mimeType: "image/jpeg")
+            let imageData = MultipartFormData(provider: .data(image.jpegData(compressionQuality: 0.5) ?? Data()), name: "image", fileName: "image.jpeg", mimeType: "image/jpeg")
             multiPartData.append(imageData)
             
             return .uploadMultipart(multiPartData)

--- a/Spark-iOS/Spark-iOS/Source/NetworkServices/User/UserService.swift
+++ b/Spark-iOS/Spark-iOS/Source/NetworkServices/User/UserService.swift
@@ -43,7 +43,7 @@ extension UserService: TargetType {
             let nickname = nickname.data(using: .utf8) ?? Data()
             multiPartData.append(MultipartFormData(provider: .data(nickname), name: "nickname"))
             if let profileImage = profileImage {
-                let profileImageData = MultipartFormData(provider: .data(profileImage.jpegData(compressionQuality: 1.0) ?? Data()), name: "image", fileName: "image.jpeg", mimeType: "image/jpeg")
+                let profileImageData = MultipartFormData(provider: .data(profileImage.jpegData(compressionQuality: 0.5) ?? Data()), name: "image", fileName: "image.jpeg", mimeType: "image/jpeg")
                 multiPartData.append(profileImageData)
             }
             


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#631

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
CompressionQuality 수정

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
각각 CompressionQuality를 1.0, 0.7, 0.5, 0.3으로 둔 이미지 사이즈입니다.
<img width="585" alt="image" src="https://user-images.githubusercontent.com/77208067/183233272-ebdf28bd-0c18-4e74-839e-c88ab6856359.png">
- 1.0에서 11초, 0.7에서 2.5초, 0.5에서 1.5초 정도 업로드 시간이 소요되었습니다.
- 육안으로 이미지 품질의 차이가 거의 구분되지 않았습니다.

## 📸 스크린샷
|비율|1.0|0.7|0.5|
|:--:|:--:|:--:|:--:|
|스크린샷|<img src = "https://user-images.githubusercontent.com/77208067/183234116-d86e7726-6e18-48a1-a274-4a84e4a26e26.jpeg" width ="400">|<img src = "https://user-images.githubusercontent.com/77208067/183234115-f621495f-354a-4d09-a258-585384939707.jpeg" width ="400">|<img src = "https://user-images.githubusercontent.com/77208067/183234109-ad14d41c-edc8-4651-ac92-0713111ceff2.jpeg" width ="400">|

## 📟 관련 이슈
- Resolved: #631 
