### PR TITLE
[Feat] #640 - 푸시알림 카테고리별 화면 전환

### DIFF
--- a/Spark-iOS/Spark-iOS/Resource/Constants/Notification.swift
+++ b/Spark-iOS/Spark-iOS/Resource/Constants/Notification.swift
@@ -20,4 +20,5 @@ extension Notification.Name {
     static let startHabitRoom = Notification.Name("startHabitRoom")
     static let sceneWillEnterForeground = Notification.Name("sceneWillEnterForeground")
     static let sceneDidEnterBackground = Notification.Name("sceneDidEnterBackground")
+    static let pushNotificationTapped = Notification.Name("pushNotificationTapped")
 }

--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -142,23 +142,28 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         guard let threadID = ThreadID(rawValue: notificationThreadID),
               let recordId: String = userInfo["recordId"] as? String,
               let roomId: String = userInfo["roomId"] as? String else { return }
-        guard let mainTBC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
-        
-        guard let window = UIApplication.shared.windows.first else { return }
-        window.rootViewController = mainTBC
-        UIView.transition(with: window, duration: 0.5, options: .transitionCrossDissolve, animations: nil)
-        
-        if recordId.isEmpty {
-            guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.habitRoom, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.habitRoom) as? HabitRoomVC else { return }
-            nextVC.roomID = Int(roomId)
+
+        let applicationState = UIApplication.shared.applicationState
+        let info: [String: Any] = ["recordID": recordId, "roomID": roomId]
+
+        if applicationState == .active || applicationState == .inactive {
+            guard let mainTBC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
             
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
-                let topVC = UIApplication.getMostTopViewController()
-                topVC?.navigationController?.pushViewController(nextVC, animated: true)
+            guard let window = UIApplication.shared.windows.first else { return }
+            window.rootViewController = mainTBC
+            UIView.transition(with: window, duration: 0.5, options: .transitionCrossDissolve, animations: nil)
+            
+            if recordId.isEmpty {
+                guard let habitRoomVC = UIStoryboard(name: Const.Storyboard.Name.habitRoom, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.habitRoom) as? HabitRoomVC else { return }
+                habitRoomVC.roomID = Int(roomId)
+                
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+                    let topVC = UIApplication.getMostTopViewController()
+                    topVC?.navigationController?.pushViewController(habitRoomVC, animated: true)
+                }
+            } else {
+                NotificationCenter.default.post(name: .pushNotificationTapped, object: nil, userInfo: info)
             }
-        } else {
-            let info: [String: Any] = ["recordID": recordId, "roomID": roomId]
-            NotificationCenter.default.post(name: .pushNotificationTapped, object: nil, userInfo: info)
         }
         
         switch threadID {

--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -142,14 +142,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         guard let threadID = ThreadID(rawValue: notificationThreadID),
               let recordId: String = userInfo["recordId"] as? String,
               let roomId: String = userInfo["roomId"] as? String else { return }
+        guard let mainTBC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
+        
+        guard let window = UIApplication.shared.windows.first else { return }
+        window.rootViewController = mainTBC
+        UIView.transition(with: window, duration: 0.5, options: .transitionCrossDissolve, animations: nil)
         
         if recordId.isEmpty {
-            guard let mainTBC = UIStoryboard(name: Const.Storyboard.Name.mainTabBar, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.mainTabBar) as? MainTBC else { return }
-            
-            guard let window = UIApplication.shared.windows.first else { return }
-            window.rootViewController = mainTBC
-            UIView.transition(with: window, duration: 0.5, options: .transitionCrossDissolve, animations: nil)
-            
             guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.habitRoom, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.habitRoom) as? HabitRoomVC else { return }
             nextVC.roomID = Int(roomId)
             

--- a/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import AuthenticationServices
 import UIKit
+import UserNotifications
 
 import Firebase
 import FirebaseMessaging
@@ -131,6 +132,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler([.sound, .banner, .list])
     }
     
+    /// background에서 푸시알림 받은 경우 또는 푸시알림 누른 경우
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
         // With swizzling disabled you must let Messaging know about the message, for Analytics
@@ -138,6 +140,16 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         
         let notificationThreadID = response.notification.request.content.threadIdentifier
         guard let threadID = ThreadID(rawValue: notificationThreadID) else { return }
+        var info: [String: Any] = ["feed": false]
+        
+        if threadID == .certification {
+            info["feed"] = true
+        } else {
+            info["feed"] = false
+            info["roomID"] = userInfo["roomId"]
+        }
+        NotificationCenter.default.post(name: .pushNotificationTapped, object: nil, userInfo: info)
+        
         switch threadID {
         case .spark:
             Analytics.logEvent(Tracking.Notification.spark, parameters: nil)

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -22,6 +22,25 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let navigationViewController = UINavigationController(rootViewController: rootViewController)
         window?.rootViewController = navigationViewController
         window?.makeKeyAndVisible()
+        
+        // 앱 종료 상태에서 푸시알림을 통해 앱에 접속하는 경우
+        if let notification = connectionOptions.notificationResponse {
+            let content = notification.notification.request.content
+            let userInfo = content.userInfo
+            guard let threadID = ThreadID(rawValue: content.threadIdentifier) else { return }
+            var info: [String: Any] = [:]
+            
+            if threadID == .certification {
+                info["feed"] = true
+            } else {
+                info["feed"] = false
+                info["roomID"] = userInfo["roomId"]
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
+                NotificationCenter.default.post(name: .pushNotificationTapped, object: nil, userInfo: info)
+            }
+        }
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
+++ b/Spark-iOS/Spark-iOS/Source/SceneDelegate.swift
@@ -27,17 +27,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let notification = connectionOptions.notificationResponse {
             let content = notification.notification.request.content
             let userInfo = content.userInfo
-            guard let threadID = ThreadID(rawValue: content.threadIdentifier) else { return }
-            var info: [String: Any] = [:]
+            guard let recordId: String = userInfo["recordId"] as? String,
+                  let roomId: String = userInfo["roomId"] as? String else { return }
             
-            if threadID == .certification {
-                info["feed"] = true
-            } else {
-                info["feed"] = false
-                info["roomID"] = userInfo["roomId"]
-            }
-
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
+            let info: [String: Any] = ["recordID": recordId, "roomID": roomId]
+            
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2.0) {
                 NotificationCenter.default.post(name: .pushNotificationTapped, object: nil, userInfo: info)
             }
         }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -106,7 +106,6 @@ class AuthTimerVC: UIViewController {
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(resetTimer(_:)), name: .resetStopWatch, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: .sceneWillEnterForeground, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(dismissToHomeVC), name: .pushNotificationTapped, object: nil)
     }
     
     private func setButton(_ button: UIButton, title: String, backgroundColor: UIColor, isEnable: Bool) {
@@ -120,7 +119,6 @@ class AuthTimerVC: UIViewController {
     private func removeObservers() {
         NotificationCenter.default.removeObserver(self, name: .sceneWillEnterForeground, object: nil)
         NotificationCenter.default.removeObserver(self, name: .sceneDidEnterBackground, object: nil)
-        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     private func dismissAuthTimerVC() {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthTimer/AuthTimerVC.swift
@@ -106,6 +106,7 @@ class AuthTimerVC: UIViewController {
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(resetTimer(_:)), name: .resetStopWatch, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(checkBackgroundTimer), name: .sceneWillEnterForeground, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissToHomeVC), name: .pushNotificationTapped, object: nil)
     }
     
     private func setButton(_ button: UIButton, title: String, backgroundColor: UIColor, isEnable: Bool) {
@@ -119,6 +120,7 @@ class AuthTimerVC: UIViewController {
     private func removeObservers() {
         NotificationCenter.default.removeObserver(self, name: .sceneWillEnterForeground, object: nil)
         NotificationCenter.default.removeObserver(self, name: .sceneDidEnterBackground, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     private func dismissAuthTimerVC() {
@@ -251,6 +253,13 @@ class AuthTimerVC: UIViewController {
                 
                 navigationController?.pushViewController(nextVC, animated: true)
             }
+        }
+    }
+    
+    @objc
+    private func dismissToHomeVC() {
+        self.dismiss(animated: true) {
+            self.presentingViewController?.navigationController?.popViewController(animated: true)
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -54,12 +54,6 @@ class AuthUploadVC: UIViewController {
         setLayout()
         setDelegate()
         setAddTarget()
-        setNotification()
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        removeObservers()
     }
 }
 
@@ -242,14 +236,6 @@ extension AuthUploadVC {
     
     private func uploadTracking() {
         Analytics.logEvent(Tracking.Select.clickUpload, parameters: nil)
-    }
-    
-    private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(dismissToHomeVC), name: .pushNotificationTapped, object: nil)
-    }
-    
-    private func removeObservers() {
-        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     // MARK: - @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Auth/AuthUpload/AuthUploadVC.swift
@@ -54,6 +54,12 @@ class AuthUploadVC: UIViewController {
         setLayout()
         setDelegate()
         setAddTarget()
+        setNotification()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        removeObservers()
     }
 }
 
@@ -238,6 +244,14 @@ extension AuthUploadVC {
         Analytics.logEvent(Tracking.Select.clickUpload, parameters: nil)
     }
     
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissToHomeVC), name: .pushNotificationTapped, object: nil)
+    }
+    
+    private func removeObservers() {
+        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
+    }
+    
     // MARK: - @objc
     
     // 두번째 플로우에서 사진 인증하기 버튼
@@ -281,6 +295,23 @@ extension AuthUploadVC {
         popupVC.modalPresentationStyle = .overFullScreen
         
         self.present(popupVC, animated: true)
+    }
+    
+    @objc
+    private func dismissToHomeVC() {
+//        switch vcType {
+//        case .photoTimer:
+//            self.dismiss(animated: true) {
+//                self.presentingViewController?.navigationController?.popViewController(animated: true)
+//            }
+//        case .photoOnly:
+//            self.dismiss(animated: true)
+//        default:
+//
+//        }
+        self.dismiss(animated: true) {
+            self.presentingViewController?.navigationController?.popViewController(animated: true)
+        }
     }
     
     @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/CodeJoinVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/CodeJoinVC.swift
@@ -82,6 +82,7 @@ extension CodeJoinVC {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissCodeJoinVC), name: .pushNotificationTapped, object: nil)
     }
     
     private func resetUI() {
@@ -103,6 +104,13 @@ extension CodeJoinVC {
     }
     
     // MARK: - @objc Function
+    
+    @objc
+    private func dismissCodeJoinVC() {
+        self.dismiss(animated: true) {
+            NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
+        }
+    }
     
     @objc
     private func textFieldDidChange(_ notification: Notification) {

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/CodeJoinVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/CodeJoinVC.swift
@@ -82,7 +82,6 @@ extension CodeJoinVC {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(dismissCodeJoinVC), name: .pushNotificationTapped, object: nil)
     }
     
     private func resetUI() {
@@ -107,9 +106,7 @@ extension CodeJoinVC {
     
     @objc
     private func dismissCodeJoinVC() {
-        self.dismiss(animated: true) {
-            NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
-        }
+        self.dismiss(animated: true)
     }
     
     @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
@@ -39,12 +39,6 @@ class JoinCheckVC: UIViewController {
         setUI()
         setAnimation()
         setLayout()
-        setNotification()
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        removeObserver()
     }
     
     // MARK: - @IBAction Properties
@@ -96,14 +90,6 @@ extension JoinCheckVC {
         enterButton.snp.makeConstraints { make in
             make.height.equalTo(self.view.frame.width*48/335)
         }
-    }
-    
-    private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(dismissToHomeVC), name: .pushNotificationTapped, object: nil)
-    }
-    
-    private func removeObserver() {
-        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     // MARK: - @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/CodeJoin/JoinCheckVC.swift
@@ -39,6 +39,12 @@ class JoinCheckVC: UIViewController {
         setUI()
         setAnimation()
         setLayout()
+        setNotification()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        removeObserver()
     }
     
     // MARK: - @IBAction Properties
@@ -90,6 +96,21 @@ extension JoinCheckVC {
         enterButton.snp.makeConstraints { make in
             make.height.equalTo(self.view.frame.width*48/335)
         }
+    }
+    
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissToHomeVC), name: .pushNotificationTapped, object: nil)
+    }
+    
+    private func removeObserver() {
+        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
+    }
+    
+    // MARK: - @objc
+    
+    @objc
+    private func dismissToHomeVC() {
+        presentingViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -38,6 +38,12 @@ class CreateAuthVC: UIViewController {
         setAddTarget()
         setAuthViewState()
         setGesture()
+        setNotification()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        removeObserver()
     }
     
     // MARK: - Methods
@@ -95,6 +101,14 @@ class CreateAuthVC: UIViewController {
         createButton.addTarget(self, action: #selector(touchCreateButton), for: .touchUpInside)
     }
     
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissToHomeVC), name: .pushNotificationTapped, object: nil)
+    }
+    
+    private func removeObserver() {
+        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
+    }
+    
     @objc
     private func touchCreateButton() {
         guard let dialogVC = UIStoryboard(name: Const.Storyboard.Name.dialogue, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.dialogue) as? DialogueVC else { return }
@@ -141,6 +155,11 @@ class CreateAuthVC: UIViewController {
     @objc
     private func popToCreateRoomVC() {
         navigationController?.popViewController(animated: true)
+    }
+    
+    @objc
+    private func dismissToHomeVC() {
+        self.dismiss(animated: true)
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateAuthVC.swift
@@ -38,12 +38,6 @@ class CreateAuthVC: UIViewController {
         setAddTarget()
         setAuthViewState()
         setGesture()
-        setNotification()
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        removeObserver()
     }
     
     // MARK: - Methods
@@ -99,14 +93,6 @@ class CreateAuthVC: UIViewController {
     
     private func setAddTarget() {
         createButton.addTarget(self, action: #selector(touchCreateButton), for: .touchUpInside)
-    }
-    
-    private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(dismissToHomeVC), name: .pushNotificationTapped, object: nil)
-    }
-    
-    private func removeObserver() {
-        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -80,7 +80,6 @@ class CreateRoomVC: UIViewController {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(dismissCreateRoomVC), name: .pushNotificationTapped, object: nil)
     }
     
     private func setAddTarget() {
@@ -89,7 +88,6 @@ class CreateRoomVC: UIViewController {
     
     private func removeObservers() {
         NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     // MARK: - Screen Change

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateRoomVC.swift
@@ -80,6 +80,7 @@ class CreateRoomVC: UIViewController {
     
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(textFieldDidChange(_:)), name: UITextField.textDidChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissCreateRoomVC), name: .pushNotificationTapped, object: nil)
     }
     
     private func setAddTarget() {
@@ -88,10 +89,12 @@ class CreateRoomVC: UIViewController {
     
     private func removeObservers() {
         NotificationCenter.default.removeObserver(self, name: UITextField.textDidChangeNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     // MARK: - Screen Change
 
+    @objc
     private func dismissCreateRoomVC() {
         dismiss(animated: true, completion: nil)
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -33,13 +33,7 @@ class CreateSuccessVC: UIViewController {
         setUI()
         setLayout()
         setAddTarget()
-        setNotification()
         getRoomCodeWithAPI(roomId: self.roomId ?? 0)
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        removeObserver()
     }
     
     // MARK: - Custom Methods
@@ -75,14 +69,6 @@ class CreateSuccessVC: UIViewController {
         ticketLottieView.contentMode = .scaleAspectFit
         ticketLottieView.loopMode = .loop
         ticketLottieView.play()
-    }
-    
-    private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(touchHomeButton), name: .pushNotificationTapped, object: nil)
-    }
-    
-    private func removeObserver() {
-        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     // MARK: - @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Create/CreateSuccessVC.swift
@@ -33,7 +33,13 @@ class CreateSuccessVC: UIViewController {
         setUI()
         setLayout()
         setAddTarget()
+        setNotification()
         getRoomCodeWithAPI(roomId: self.roomId ?? 0)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        removeObserver()
     }
     
     // MARK: - Custom Methods
@@ -69,6 +75,14 @@ class CreateSuccessVC: UIViewController {
         ticketLottieView.contentMode = .scaleAspectFit
         ticketLottieView.loopMode = .loop
         ticketLottieView.play()
+    }
+    
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(touchHomeButton), name: .pushNotificationTapped, object: nil)
+    }
+    
+    private func removeObserver() {
+        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     // MARK: - @objc

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -329,13 +329,15 @@ extension HomeVC {
     private func enterHabitRoomVC(_ notification: NSNotification) {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.habitRoom, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.habitRoom) as? HabitRoomVC else { return }
         
-        guard let roomID: String = notification.userInfo?["roomID"] as? String else { return }
-        nextVC.roomID = Int(roomID)
-        if  UIApplication.getMostTopViewController() == self || notification.name == .startHabitRoom {
-            navigationController?.pushViewController(nextVC, animated: true)
-        } else {
-            self.popToHomeVC {
-                self.navigationController?.pushViewController(nextVC, animated: true)
+        if notification.userInfo?["recordID"] == nil {
+            guard let roomID: String = notification.userInfo?["roomID"] as? String else { return }
+            nextVC.roomID = Int(roomID)
+            if  UIApplication.getMostTopViewController() == self || notification.name == .startHabitRoom {
+                navigationController?.pushViewController(nextVC, animated: true)
+            } else {
+                self.popToHomeVC {
+                    self.navigationController?.pushViewController(nextVC, animated: true)
+                }
             }
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -227,6 +227,7 @@ extension HomeVC {
         NotificationCenter.default.addObserver(self, selector: #selector(setToastMessage(_:)), name: .leaveRoom, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateHome), name: .updateHome, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(enterHabitRoomVC(_:)), name: .startHabitRoom, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(enterHabitRoomVC(_:)), name: .pushNotificationTapped, object: nil)
     }
     
     private func viewTracking() {
@@ -327,10 +328,21 @@ extension HomeVC {
     @objc
     private func enterHabitRoomVC(_ notification: NSNotification) {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.habitRoom, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.habitRoom) as? HabitRoomVC else { return }
-        guard let roomID: Int = notification.userInfo?["roomID"] as? Int else { return }
-        nextVC.roomID = roomID
         
-        navigationController?.pushViewController(nextVC, animated: true)
+        guard let roomID: String = notification.userInfo?["roomID"] as? String else { return }
+        nextVC.roomID = Int(roomID)
+        if  UIApplication.getMostTopViewController() == self || notification.name == .startHabitRoom {
+            navigationController?.pushViewController(nextVC, animated: true)
+        } else {
+            self.popToHomeVC {
+                self.navigationController?.pushViewController(nextVC, animated: true)
+            }
+        }
+    }
+    
+    private func popToHomeVC(_ completion: () -> Void) {
+        navigationController?.popToRootViewController(animated: true)
+        completion()
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/HomeVC.swift
@@ -329,22 +329,13 @@ extension HomeVC {
     private func enterHabitRoomVC(_ notification: NSNotification) {
         guard let nextVC = UIStoryboard(name: Const.Storyboard.Name.habitRoom, bundle: nil).instantiateViewController(withIdentifier: Const.ViewController.Identifier.habitRoom) as? HabitRoomVC else { return }
         
-        if notification.userInfo?["recordID"] == nil {
-            guard let roomID: String = notification.userInfo?["roomID"] as? String else { return }
+        guard let recordId = notification.userInfo?["recordID"] as? String,
+              let roomID = notification.userInfo?["roomID"] as? String else { return }
+        
+        if recordId.isEmpty {
             nextVC.roomID = Int(roomID)
-            if  UIApplication.getMostTopViewController() == self || notification.name == .startHabitRoom {
-                navigationController?.pushViewController(nextVC, animated: true)
-            } else {
-                self.popToHomeVC {
-                    self.navigationController?.pushViewController(nextVC, animated: true)
-                }
-            }
+            navigationController?.pushViewController(nextVC, animated: true)
         }
-    }
-    
-    private func popToHomeVC(_ completion: () -> Void) {
-        navigationController?.popToRootViewController(animated: true)
-        completion()
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
@@ -151,8 +151,8 @@ extension MainTBC {
     @objc
     func showTab(_ notification: Notification) {
         if let userInfo = notification.userInfo {
-            if let feed = userInfo["feed"] as? Bool {
-                selectedIndex = feed ? 0 : 1
+            if let recordId = userInfo["recordID"] as? String {
+                selectedIndex = recordId.isEmpty ? 1 : 0
             }
         }
     }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/TabBar/MainTBC.swift
@@ -100,6 +100,7 @@ extension MainTBC {
     private func setNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(setAppearFloatingButtonLayout), name: .appearFloatingButton, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(setDisappearFloatingButton), name: .disappearFloatingButton, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(showTab(_:)), name: .pushNotificationTapped, object: nil)
     }
     
     private func presentToCodeJoinVC() {
@@ -143,6 +144,16 @@ extension MainTBC {
         } else {
             floatingButton.buttonColor = .sparkDarkPinkred
             floatingButton.buttonImageColor = .sparkWhite
+        }
+    }
+    
+    /// 푸시알림 종류에 따라 탭(feed/home) 이동
+    @objc
+    func showTab(_ notification: Notification) {
+        if let userInfo = notification.userInfo {
+            if let feed = userInfo["feed"] as? Bool {
+                selectedIndex = feed ? 0 : 1
+            }
         }
     }
 }

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -90,6 +90,7 @@ class WaitingVC: UIViewController {
         setAuthLabel()
         setNavigationBar(title: roomName ?? "")
         setGestureRecognizer()
+        setNotification()
         viewTracking()
     }
     
@@ -100,6 +101,11 @@ class WaitingVC: UIViewController {
         getWaitingRoomWithAPI(roomID: self.roomId ?? 0)
         setTabBar()
         setFloatingButton()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        removeObserver()
     }
 }
 
@@ -430,16 +436,30 @@ extension WaitingVC {
         present(alert, animated: true)
     }
     
+    private func setNotification() {
+        if  fromWhereStatus == .makeRoom {
+            NotificationCenter.default.addObserver(self, selector: #selector(dismissWaitingVC), name: .pushNotificationTapped, object: nil)
+        } else if fromWhereStatus == .joinCode {
+            NotificationCenter.default.addObserver(self, selector: #selector(dismissFromJoinCode), name: .pushNotificationTapped, object: nil)
+        }
+    }
+    
+    private func removeObserver() {
+        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
+    }
+    
     // MARK: - Screen Change
     
     private func popToHomeVC() {
         navigationController?.popViewController(animated: true)
     }
     
+    @objc
     private func dismissWaitingVC() {
         presentingViewController?.presentingViewController?.dismiss(animated: true)
     }
     
+    @objc
     private func dismissFromJoinCode() {
         presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true)
         NotificationCenter.default.post(name: .updateHome, object: nil)
@@ -501,6 +521,7 @@ extension WaitingVC {
                 case .fromHome:
                     self.popToHomeVC()
                 case .makeRoom:
+                    print("방 만들고 왔어용")
                     self.dismissWaitingVC()
                 case .joinCode:
                     // 코드로 참여시에는 createButton 이 히든되어 있어서 아무런 동작이 필요하지 않다.
@@ -520,7 +541,7 @@ extension WaitingVC {
     }
     
     private func postStartHabitNotification() {
-        NotificationCenter.default.post(name: .startHabitRoom, object: nil, userInfo: ["roomID": roomId ?? 0])
+        NotificationCenter.default.post(name: .startHabitRoom, object: nil, userInfo: ["roomID": String(roomId ?? 0)])
     }
 }
 

--- a/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/ViewControllers/Waiting/WaitingVC.swift
@@ -90,7 +90,6 @@ class WaitingVC: UIViewController {
         setAuthLabel()
         setNavigationBar(title: roomName ?? "")
         setGestureRecognizer()
-        setNotification()
         viewTracking()
     }
     
@@ -101,11 +100,6 @@ class WaitingVC: UIViewController {
         getWaitingRoomWithAPI(roomID: self.roomId ?? 0)
         setTabBar()
         setFloatingButton()
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        removeObserver()
     }
 }
 
@@ -434,18 +428,6 @@ extension WaitingVC {
         }))
         
         present(alert, animated: true)
-    }
-    
-    private func setNotification() {
-        if  fromWhereStatus == .makeRoom {
-            NotificationCenter.default.addObserver(self, selector: #selector(dismissWaitingVC), name: .pushNotificationTapped, object: nil)
-        } else if fromWhereStatus == .joinCode {
-            NotificationCenter.default.addObserver(self, selector: #selector(dismissFromJoinCode), name: .pushNotificationTapped, object: nil)
-        }
-    }
-    
-    private func removeObserver() {
-        NotificationCenter.default.removeObserver(self, name: .pushNotificationTapped, object: nil)
     }
     
     // MARK: - Screen Change


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#640

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 수빈이가 올린 #641 풀리퀘 코드리뷰 하고 진행하였습니다.
- SceneDelegate 에서 백그라운드 상태에서 푸시알림을 통해 앱에 접근하는 경우에 notification 을 전송하는 코드를 그대로 사용하였습니다.
  - 코드리뷰는 다른 의견이었는데 이렇게 해결한 이유는 AppDelegate 에서 진행하면 SplashVC 로의 화면전환을 구현해야하는데 SceneDelegate 에서 진행하면 이미 SplashVC 로의 구현이 되어 있고, 이때 푸시알림을 통해서 접근하는 경우에만 notification 을 전송해주면 되었기 때문입니다.
- `AppDelegate` 에서 분기처리를 진행한 이유는 하지 않으면 background 의 경우에도 중복되어 적용되기 때문이었습니다.
- `HomeVC` 에서 수정사항은 다음과 같습니다.
  - 서버에서 recordId 는 "" 빈문자열로 넘어오기 떄문에 nil 값을 가질 수 없습니당. 그래서 조건문자체가 먹히지 않았습니다 🥲
  - 삭제한 조건문은 popToHomeVC 를 사용할 시나리오가 없을거라 생각하고 삭제했당! 혹시 제가 놓친 시나리오가 있다면 리뷰해주세용
 
## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- #641 풀리퀘와 비교하여 HomeVC 와 AppDelegate 만 수정되었으니 그것만 봐주시면 됩니당
- 이것도 코드리뷰 거쳐서 수빈이가 이 풀리퀘 풀받고, 나머지 코드리뷰도 반영해주면 꼬이지 않을 것 같습니당 🧑‍🏭

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|백그라운드에서 습관방|<img src = "https://user-images.githubusercontent.com/69136340/191081614-c2e477a9-f2e1-485e-b44d-da7cdefa7ae1.MP4" width ="250">|
|백그라운드에서 피드|<img src = "https://user-images.githubusercontent.com/69136340/191082220-7228f9cf-93fc-44da-960b-58dded677ce8.mov" width ="250">|
|포그라운드에서 습관방|<img src = "https://user-images.githubusercontent.com/69136340/191081628-62aac97e-708e-4267-86cc-7431fd0e78ce.MP4" width ="250">|
|포그라운드에서 피드|<img src = "https://user-images.githubusercontent.com/69136340/191082490-d0fa29ac-a715-4caa-a56b-bdbe5fbfd12e.MP4" width ="250">|

## 📟 관련 이슈
- Resolved: #640
