### PR TITLE
[Fix] #617 - 인증사진 더보기 뷰 이미지 사이즈 medium로 변경

### DIFF
--- a/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.swift
@@ -66,7 +66,7 @@ class MoreStorageCVC: UICollectionViewCell {
                   timerCount: String?) {
         switch status {
         case "DONE":
-            certificationImage.updateImage(mainImage, type: .large, placeholder: .sparkDarkGray)
+            certificationImage.updateImage(mainImage, type: .medium, placeholder: .sparkDarkGray)
         case "REST":
             certificationImage.image = UIImage(named: "stickerRestBigMybox")
         default:
@@ -94,7 +94,7 @@ class MoreStorageCVC: UICollectionViewCell {
                      status: String) {
         switch status {
         case "DONE":
-            certificationImage.updateImage(mainImage, type: .large, placeholder: .sparkDarkGray)
+            certificationImage.updateImage(mainImage, type: .medium, placeholder: .sparkDarkGray)
             self.isUserInteractionEnabled = true
         case "REST":
             certificationImage.image = UIImage(named: "stickerRestBigMybox")

--- a/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.swift
+++ b/Spark-iOS/Spark-iOS/Source/Cells/StorageMore/MoreStorageCVC.swift
@@ -66,7 +66,7 @@ class MoreStorageCVC: UICollectionViewCell {
                   timerCount: String?) {
         switch status {
         case "DONE":
-            certificationImage.updateImage(mainImage, placeholder: .sparkDarkGray)
+            certificationImage.updateImage(mainImage, type: .large, placeholder: .sparkDarkGray)
         case "REST":
             certificationImage.image = UIImage(named: "stickerRestBigMybox")
         default:
@@ -94,7 +94,7 @@ class MoreStorageCVC: UICollectionViewCell {
                      status: String) {
         switch status {
         case "DONE":
-            certificationImage.updateImage(mainImage, type: .small, placeholder: .sparkDarkGray)
+            certificationImage.updateImage(mainImage, type: .large, placeholder: .sparkDarkGray)
             self.isUserInteractionEnabled = true
         case "REST":
             certificationImage.image = UIImage(named: "stickerRestBigMybox")


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#617

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
인증사진 더보기 뷰 이미지 사이즈 large로 변경했습니다.
진작에 할걸.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://user-images.githubusercontent.com/77208067/197708945-ea70a00a-9dd9-4f91-ab2a-9eccafb5267d.png" width ="250">|

## 10.27 수정

아래 영상 보시면 알 수 있듯이, large의 경우에 이미지 다운로드 속도가 꽤나 느립니다... 그리고 medium과 큰 차이가 느껴지지 않아서 medium으로 하면 좋을 것 같습니다!

## 영상
#### large

https://user-images.githubusercontent.com/77208067/198308207-ee1adba7-8b5e-4199-b597-dad362e7e7bc.mp4

#### medium

https://user-images.githubusercontent.com/77208067/198308233-4bad7d4f-42cb-4850-a1b4-c7f3b661885b.mp4

## 📟 관련 이슈
- Resolved: #617 
