### PR TITLE
[Chore] #692 - Fastlane 으로 Matchfile 생성 및 fastfile 수정

### DIFF
--- a/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
+++ b/Spark-iOS/Spark-iOS.xcodeproj/project.pbxproj
@@ -2028,9 +2028,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Spark-iOS/Spark-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T8C9SSEX5G;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Spark-iOS/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Spark;
@@ -2051,6 +2053,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeamSparker.Spark;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.TeamSparker.Spark";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -2066,9 +2069,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Spark-iOS/Spark-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T8C9SSEX5G;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Spark-iOS/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Spark;
@@ -2089,6 +2094,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeamSparker.Spark;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.TeamSparker.Spark";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -2165,9 +2171,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Spark-iOS/Spark-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T8C9SSEX5G;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Spark-iOS/Resource/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Spark;
@@ -2188,6 +2196,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeamSparker.Spark;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.TeamSparker.Spark";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -2198,9 +2207,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T8C9SSEX5G;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SparkNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = SparkNotificationService;
@@ -2214,6 +2225,8 @@
 				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeamSparker.Spark.SparkNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.TeamSparker.Spark.SparkNotificationService";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -2225,9 +2238,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T8C9SSEX5G;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SparkNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = SparkNotificationService;
@@ -2241,6 +2256,8 @@
 				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeamSparker.Spark.SparkNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.TeamSparker.Spark.SparkNotificationService";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -2252,9 +2269,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = T8C9SSEX5G;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = T8C9SSEX5G;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SparkNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = SparkNotificationService;
@@ -2268,6 +2287,8 @@
 				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeamSparker.Spark.SparkNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.TeamSparker.Spark.SparkNotificationService";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Spark-iOS/fastlane/Fastfile
+++ b/Spark-iOS/fastlane/Fastfile
@@ -16,6 +16,16 @@
 default_platform(:ios)
 
 platform :ios do
+  lane :certificates do
+    match(type: "appstore",
+          app_identifier:["com.TeamSparker.Spark", "com.TeamSparker.Spark.SparkNotificationService"],
+          readonly: true)
+    match(type: "development",
+          app_identifier:["com.TeamSparker.Spark", "com.TeamSparker.Spark.SparkNotificationService"],
+          readonly: true)
+  end
+
+
   desc "Push a new beta build to TestFlight"
   lane :beta do
     get_certificates

--- a/Spark-iOS/fastlane/Matchfile
+++ b/Spark-iOS/fastlane/Matchfile
@@ -1,0 +1,13 @@
+git_url("https://github.com/hyun99999/fastlane-spark")
+
+storage_mode("git")
+
+type("development") # The default type, can be: appstore, adhoc, enterprise or development
+
+# app_identifier(["tools.fastlane.app", "tools.fastlane.app2"])
+# username("user@fastlane.tools") # Your Apple Developer Portal username
+
+# For all available options run `fastlane match --help`
+# Remove the # in the beginning of the line to enable the other options
+
+# The docs are available on https://docs.fastlane.tools/actions/match

--- a/Spark-iOS/fastlane/README.md
+++ b/Spark-iOS/fastlane/README.md
@@ -15,6 +15,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## iOS
 
+### ios certificates
+
+```sh
+[bundle exec] fastlane ios certificates
+```
+
+
+
 ### ios beta
 
 ```sh


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- #692

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- fastlane match 방식을 공부해보면서 적용해봐야겠다고... 생각했습니다!! 
- fastfile 에서 certificates lane 생성해서 인증서와 프로비저닝 프로필 읽기전용으로 설치할 수 있도록 설정
- 프로젝트 파일에서 수동으로 match 로 설치한 인증서와 프로비저닝 프로필으로 설정
- fastfile 에 lane 을 다음과 같이 생성해둬서 `fastlane certificates` 를 실행하시면 설치할 수 있습니다. Xcode Signing & Capabilities 수동 설정도 같이 푸시해둬서 아직 안해봐서.. 모르지만 설치만 완료되면 문제없을 것 같습니당. 문제가 생기면 말씀해주세용 😉
```bash
lane :certificates do
    match(type: "appstore",
          app_identifier:["com.mainapp", "com.notificationService"],
          readonly: true)
    match(type: "development",
          app_identifier:["com.mainapp", "com.notificationService"],
          readonly: true)
end
```

혹은, `fastlane match appstore -a com.mainapp, com.notificationService --readonly` 이렇게 사용하셔도 됩니당 `fastlane match development -a com.mainapp, com.notificationService --readonly` 도 해주면 되겠습니당
readonly 를 하면 읽기전용이라서 인증서를 추가로 생성하지 않는다고 하네여

추가적으로 공부하면서 code signing 에 대해서도 공부해봤어요 아래 정리한 글 남겨드릴게여
https://www.notion.so/iOS-code-signing-Fastlane-match-98df1ba69a9c40c69512e70f44c340ba?pvs=4

> 더 깊은 내용은 [[iOS] Certificate 와 Provisioning profile](https://sujinnaljin.medium.com/ios-certificate-%EC%99%80-provisioning-profile-e1b9455e8a51) 여기서 보시면 좋을 것 같네요. 저는 match 를 진행하기 위한 흐름으로 정리했고, 이 글은 정말 깊게 정리해둔 것 같습니당

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- private repo 에 인증서와 프로비저닝 프로파일을 올려뒀기 때문에 프라이빗 레포에 초대했습니다.
- `fastlane certificates` 등의 match 작업을 실행할 때 git repository 주소를 입력하라고 하는데 해당 주소를 입력하면 되고,(https://github.com/hyun99999/fastlane-spark) passphrase 를 입력하면 됩니다. 요건 별도로 전달해드리겠습니다.

### match 방법을 공부하면서 느낀 점
- sigh and cert 방식은 기존의 인증서를 지우지 않아도 되지만, 개발자에게 직접 파일을 넘겨주기 위한 설정의 과정이 필요해서 번거로웠던 것 같습니다.

- match 를 적용한 프로젝트가 소규모 인원이었기 때문에 이렇게 중간에 도입해서 인증서를 새로 만들더라도 match 에서 private repo 를 활용한 방식이 더 적용하기 편했던 것 같습니다. 혹여나 프로젝트 중간에 타겟이 추가되어 certificate 와 profile 을 추가로 설치하는 과정도 손쉽게 할 수 있는 것이 장점이라고 느꼈습니다.

- 정리해보자면 개발자마다 인증서를 만들지 않아도 되고, 한 곳에서 관리하기 쉽고, 다른 개발자들도 쉽게 설치할 수 있는 것이 장점이라고 느꼈습니다. 기존의 인증서를 지워야 하지만 fastlane 에서 손쉽게 생성할 수도 있어 불편하지 않았습니다.

## 📟 관련 이슈
- Resolved: #692
